### PR TITLE
fix: Use returnDocument instead of returnOriginal

### DIFF
--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -617,7 +617,7 @@ describe('model', () => {
         },
         {
           ignoreUndefined: true,
-          returnOriginal: false,
+          returnDocument: 'after',
         }
       );
 
@@ -653,7 +653,7 @@ describe('model', () => {
         },
         {
           ignoreUndefined: true,
-          returnOriginal: false,
+          returnDocument: 'after',
         }
       );
 
@@ -679,7 +679,7 @@ describe('model', () => {
         {},
         {
           ignoreUndefined: true,
-          returnOriginal: false,
+          returnDocument: 'after',
         }
       );
 
@@ -711,7 +711,7 @@ describe('model', () => {
           },
           {
             ignoreUndefined: true,
-            returnOriginal: false,
+            returnDocument: 'after',
             upsert: true,
           }
         );
@@ -733,7 +733,7 @@ describe('model', () => {
           },
           {
             ignoreUndefined: true,
-            returnOriginal: false,
+            returnDocument: 'after',
             upsert: true,
           }
         );
@@ -755,7 +755,7 @@ describe('model', () => {
           },
           {
             ignoreUndefined: true,
-            returnOriginal: false,
+            returnDocument: 'after',
             upsert: true,
           }
         );
@@ -777,7 +777,7 @@ describe('model', () => {
           },
           {
             ignoreUndefined: true,
-            returnOriginal: false,
+            returnDocument: 'after',
             upsert: true,
           }
         );
@@ -810,7 +810,7 @@ describe('model', () => {
           },
           {
             ignoreUndefined: true,
-            returnOriginal: false,
+            returnDocument: 'after',
             upsert: true,
           }
         );
@@ -848,7 +848,7 @@ describe('model', () => {
           },
           {
             ignoreUndefined: true,
-            returnOriginal: false,
+            returnDocument: 'after',
             upsert: true,
           }
         );
@@ -1385,7 +1385,7 @@ describe('model', () => {
         },
         {
           ignoreUndefined: true,
-          returnOriginal: false,
+          returnDocument: 'after',
           upsert: true,
         }
       );

--- a/src/model.ts
+++ b/src/model.ts
@@ -636,7 +636,7 @@ export function build<TSchema extends BaseSchema, TDefaults extends Partial<TSch
         ...(options?.upsert && Object.keys($setOnInsert).length > 0 && { $setOnInsert }),
       },
       {
-        returnOriginal: false,
+        returnDocument: 'after',
         ...model.defaultOptions,
         ...options,
       } as FindOneAndUpdateOption<TSchema>


### PR DESCRIPTION
I noticed this deprecation message in the logs:
```
collection.findOneAndUpdate option [returnOriginal] is deprecated and will be removed in a later version
```

When I looked up the [docs](https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOneAndUpdate), I found:
![image](https://user-images.githubusercontent.com/3028854/120705287-a271e600-c485-11eb-8e7c-e675c564bbf8.png)


## 🎉 Changes

* replace `returnOriginal` with `returnDocument`