### PR TITLE
fix: Customize mongo URL in benchmark tool

### DIFF
--- a/benchmark/setup.js
+++ b/benchmark/setup.js
@@ -1,7 +1,7 @@
+import arg from 'arg';
 import mongodb from 'mongodb';
 import mongoose from 'mongoose';
 import Papr from '../esm/index.js';
-import arg from 'arg';
 
 const args = arg({
   '--url': String,

--- a/benchmark/setup.js
+++ b/benchmark/setup.js
@@ -9,7 +9,7 @@ const args = arg({
 });
 
 const DATABASE = 'benchmark';
-const URL = Object.prototype.hasOwnProperty.call(args, '--url') && args['--url'].length > 0 ? args['--url'] : 'mongodb://localhost:27017';
+const URL = args['--url'] && args['--url'].length > 0 ? args['--url'] : 'mongodb://localhost:27017';
 
 export const COLLECTIONS = ['mongodb', 'mongoose', 'papr'];
 

--- a/benchmark/setup.js
+++ b/benchmark/setup.js
@@ -1,9 +1,15 @@
 import mongodb from 'mongodb';
 import mongoose from 'mongoose';
 import Papr from '../esm/index.js';
+import arg from 'arg';
+
+const args = arg({
+  '--url': String,
+  '-u': '--url'
+});
 
 const DATABASE = 'benchmark';
-const URL = 'mongodb://localhost:27017';
+const URL = Object.prototype.hasOwnProperty.call(args, '--url') && args['--url'].length > 0 ? args['--url'] : 'mongodb://localhost:27017';
 
 export const COLLECTIONS = ['mongodb', 'mongoose', 'papr'];
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ papr.updateOne ~ 826.21 ops/sec
 mongoose.updateOne ~ 766.84 ops/sec
 ```
 
-This benchmark can be run locally with `yarn benchmark`, provided a MongoDB server is running locally at the default port.
+This benchmark can be run locally with `yarn benchmark`, by default the benchmark tool will use `mongodb://localhost:27017`; however you can pass your own url by using the argument `--url` or `-u`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/mongodb": "3.6.17",
     "@typescript-eslint/eslint-plugin": "4.28.0",
     "@typescript-eslint/parser": "4.28.0",
+    "arg": "5.0.0",
     "docsify-cli": "4.4.3",
     "eslint": "7.29.0",
     "eslint-config-prettier": "8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,6 +1975,11 @@ anymatch@^3.0.3, anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+arg@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.0.tgz#a20e2bb5710e82950a516b3f933fee5ed478be90"
+  integrity sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ==
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"


### PR DESCRIPTION
… their own mongodb instance url

Happy to remove the `arg` dependency if you don't want to add that, I can parse it manually.