### PR TITLE
test: Fail early in build tests

### DIFF
--- a/tests/build.sh
+++ b/tests/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 yarn build
 
 npm pack


### PR DESCRIPTION
#26 has some errors in the build tests, but the bash script running those tests does not fail on errors, so CI shows those tests as :heavy_check_mark:.