### PR TITLE
test: Update collections in benchmark

### DIFF
--- a/benchmark/mongoose.js
+++ b/benchmark/mongoose.js
@@ -39,7 +39,7 @@ const sampleSchema = new mongoose.Schema(
     ],
     scores: [Number],
     source: {
-      default: 'mongoose',
+      default: 'mongoosetests',
       enum: COLLECTIONS,
       required: true,
       type: String,
@@ -59,4 +59,4 @@ const sampleSchema = new mongoose.Schema(
   }
 );
 
-export default mongoose.model('mongoose', sampleSchema);
+export default mongoose.model('mongoosetests', sampleSchema);

--- a/benchmark/papr.js
+++ b/benchmark/papr.js
@@ -30,11 +30,11 @@ const sampleSchema = schema(
     zip: types.number(),
   },
   {
-    defaults: { source: 'papr' },
+    defaults: { source: 'paprtests' },
     timestamps: true,
   }
 );
 
-const SamplePapr = papr.model('papr', sampleSchema);
+const SamplePapr = papr.model('paprtests', sampleSchema);
 
 export default SamplePapr;

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -5,7 +5,7 @@ import setup, { db } from './setup.js';
 
 const INSERT_COUNT = 10000;
 const FIND_COUNT = 10000;
-const UPDATE_COUNT = 5000;
+const UPDATE_COUNT = 10000;
 const IDS = {
   mongodb: [],
   mongoose: [],
@@ -85,7 +85,7 @@ async function test(name, operations, action) {
 }
 
 async function run() {
-  const mongodb = await db.collection('mongodb');
+  const mongodb = await db.collection('mongodbtests');
 
   await test('mongodb.insertOne', INSERT_COUNT, async () => {
     const result = await mongodb.insertOne(randomDocument('mongodb'));
@@ -115,7 +115,7 @@ async function run() {
   console.log('---');
 
   await test('mongodb.updateOne', UPDATE_COUNT, async () => {
-    await mongodb.updateOne(randomQueryID('papr'), { $set: { age: random(100) }, });
+    await mongodb.updateOne(randomQueryID('mongodb'), { $set: { age: random(100) }, });
   });
   await test('papr.updateOne', UPDATE_COUNT, async () => {
     await SamplePapr.updateOne(randomQueryID('papr'), { $set: { age: random(100) }, });

--- a/benchmark/setup.js
+++ b/benchmark/setup.js
@@ -33,7 +33,7 @@ if (args['--help']) {
 const DATABASE = args['--db'] && args['--db'] ? args['--db'] : `benchmark-${Date.now()}`;
 const URL = args['--url'] && args['--url'].length > 0 ? args['--url'] : 'mongodb://localhost:27017';
 
-export const COLLECTIONS = ['mongodb', 'mongoose', 'papr'];
+export const COLLECTIONS = ['mongodbtests', 'mongoosetests', 'paprtests'];
 
 export const papr = new Papr();
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,18 +57,24 @@ The JSON Schema validation feature is available in MongoDB server since version 
 Due to its bare feature set and validation run in the MongoDB server, Papr is _fast_.
 
 ```
-mongodb.insertOne ~ 985.17 ops/sec
-papr.insertOne ~ 886.95 ops/sec
-mongoose.create ~ 554.58 ops/sec
+mongodb.insertOne ~ 866.04 ops/sec
+papr.insertOne ~ 792.34 ops/sec
+mongoose.create ~ 549.95 ops/sec
 ---
-mongodb.find ~ 676.18 ops/sec
-papr.find ~ 667.17 ops/sec
-mongoose.find ~ 514.02 ops/sec
+mongodb.find ~ 672.63 ops/sec
+papr.find ~ 632.43 ops/sec
+mongoose.find ~ 508.21 ops/sec
 ---
-mongodb.updateOne ~ 970.25 ops/sec
-papr.updateOne ~ 826.21 ops/sec
-mongoose.updateOne ~ 766.84 ops/sec
+mongodb.updateOne ~ 811.47 ops/sec
+papr.updateOne ~ 726.20 ops/sec
+mongoose.updateOne ~ 673.07 ops/sec
 ```
+
+The benchmark above are from a benchmark with:
+
+- Node.js 14.16.0.
+- MongoDB server v4.4.6
+- `mongodb` v3.6.10
 
 This benchmark can be run locally with `yarn benchmark`. Run `yarn benchmark --help` for more information on available arguments.
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "jsdoc-api": "7.0.1",
     "jsdoc-parse": "6.0.0",
     "lint-staged": "11.0.0",
-    "mongodb": "3.6.9",
+    "mongodb": "3.6.10",
     "mongodb-memory-server-global-4.4": "7.2.0",
     "mongoose": "5.12.12",
     "prettier": "2.3.0",
@@ -86,6 +86,9 @@
   },
   "peerDependencies": {
     "mongodb": "3.x"
+  },
+  "resolutions": {
+    "mongodb": "3.6.10"
   },
   "commitlint": {
     "extends": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5496,23 +5496,10 @@ mongodb-memory-server-global-4.4@7.2.0:
     mongodb-memory-server-core "7.2.0"
     tslib "^2.3.0"
 
-mongodb@3.6.8:
-  version "3.6.8"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.8.tgz#3e2632af81915b3ff99b7681121ca0895e8ed407"
-  integrity sha512-sDjJvI73WjON1vapcbyBD3Ao9/VN3TKYY8/QX9EPbs22KaCSrQ5rXo5ZZd44tWJ3wl3FlnrFZ+KyUtNH6+1ZPQ==
-  dependencies:
-    bl "^2.2.1"
-    bson "^1.1.4"
-    denque "^1.4.1"
-    optional-require "^1.0.3"
-    safe-buffer "^5.1.2"
-  optionalDependencies:
-    saslprep "^1.0.0"
-
-mongodb@3.6.9, mongodb@^3.6.9:
-  version "3.6.9"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.9.tgz#4889cf529724267d393a18275d6cf19d71905b1d"
-  integrity sha512-1nSCKgSunzn/CXwgOWgbPHUWOO5OfERcuOWISmqd610jn0s8BU9K4879iJVabqgpPPbA6hO7rG48eq+fGED3Mg==
+mongodb@3.6.10, mongodb@3.6.8, mongodb@^3.6.9:
+  version "3.6.10"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.10.tgz#f10e990113c86b195c8af0599b9b3a90748b6ee4"
+  integrity sha512-fvIBQBF7KwCJnDZUnFFy4WqEFP8ibdXeFANnylW19+vOwdjOAvqIzPdsNCEMT6VKTHnYu4K64AWRih0mkFms6Q==
   dependencies:
     bl "^2.2.1"
     bson "^1.1.4"


### PR DESCRIPTION
While running benchmarks for #36, I noticed that the Mongoose benchmark was not correct because Mongoose adds a final `s` to the collection name. So the collection name we were using for Mongoose tests (`mongooses`) did not have the correct indexes defined.

However even after this change, the Mongoose numbers are still worse than Papr's.

I also bumped the `mongodb` library to the latest v3.6 version available.