### PR TITLE
fix: Apply defaults in bulkWrite updateOne operations

### DIFF
--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -211,6 +211,50 @@ describe('model', () => {
             },
           },
         },
+        {
+          updateOne: {
+            filter: {},
+            update: {
+              $set: {
+                bar: 123,
+                foo: 'foo',
+              },
+            },
+          },
+        },
+        {
+          updateOne: {
+            filter: {},
+            update: {
+              $set: {
+                foo: 'foo',
+              },
+            },
+          },
+        },
+        {
+          updateOne: {
+            filter: {},
+            update: {
+              $set: {
+                bar: 123,
+                foo: 'foo',
+              },
+            },
+            upsert: true,
+          },
+        },
+        {
+          updateOne: {
+            filter: {},
+            update: {
+              $set: {
+                foo: 'foo',
+              },
+            },
+            upsert: true,
+          },
+        },
       ];
 
       await simpleModel.bulkWrite(operations);
@@ -231,6 +275,56 @@ describe('model', () => {
                 bar: 123456,
                 foo: 'foo',
               },
+            },
+          },
+          {
+            updateOne: {
+              filter: {},
+              update: {
+                $set: {
+                  bar: 123,
+                  foo: 'foo',
+                },
+              },
+            },
+          },
+          {
+            updateOne: {
+              filter: {},
+              update: {
+                $set: {
+                  foo: 'foo',
+                },
+              },
+            },
+          },
+          {
+            updateOne: {
+              filter: {},
+              update: {
+                $set: {
+                  bar: 123,
+                  foo: 'foo',
+                },
+                $setOnInsert: {
+                  bar: 123456,
+                },
+              },
+              upsert: true,
+            },
+          },
+          {
+            updateOne: {
+              filter: {},
+              update: {
+                $set: {
+                  foo: 'foo',
+                },
+                $setOnInsert: {
+                  bar: 123456,
+                },
+              },
+              upsert: true,
             },
           },
         ],

--- a/src/model.ts
+++ b/src/model.ts
@@ -319,6 +319,24 @@ export function build<TSchema extends BaseSchema, TDefaults extends Partial<TSch
               },
             },
           };
+        } else if (
+          'updateOne' in op &&
+          op.updateOne.upsert &&
+          !Array.isArray(op.updateOne.update)
+        ) {
+          operation = {
+            updateOne: {
+              ...op.updateOne,
+              update: {
+                ...op.updateOne.update,
+                // @ts-expect-error Type of the values is not recognized here
+                $setOnInsert: {
+                  ...model.defaults,
+                  ...op.updateOne.update.$setOnInsert,
+                },
+              },
+            },
+          };
         }
         return model.hasTimestamps ? timestampBulkWriteOperation(operation) : operation;
       });


### PR DESCRIPTION
We forgot to apply the default values in update+upsert operations in `bulkWrite`.