### PR TITLE
fix: Filter defaults in bulkWrite to avoid conflicts

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -3,5 +3,6 @@
 ```
 $ node --experimental-specifier-resolution=node --loader ts-node/esm ./example/insert.ts
 $ node --experimental-specifier-resolution=node --loader ts-node/esm ./example/find.ts
+$ node --experimental-specifier-resolution=node --loader ts-node/esm ./example/bulkWrite.ts
 $ node --experimental-specifier-resolution=node --loader ts-node/esm ./example/transaction.ts
 ```

--- a/example/bulkWrite.ts
+++ b/example/bulkWrite.ts
@@ -1,0 +1,33 @@
+import User from './User';
+import { connect, disconnect } from './papr';
+
+await connect();
+
+const users = await User.bulkWrite([
+  {
+    insertOne: {
+      document: {
+        firstName: 'John',
+        lastName: 'Wick',
+      },
+    },
+  },
+  {
+    updateOne: {
+      filter: {
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+      update: {
+        $set: {
+          active: true,
+          age: 20,
+        },
+      },
+      upsert: true,
+    },
+  },
+]);
+console.log(users);
+
+await disconnect();

--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -248,6 +248,20 @@ describe('model', () => {
           updateOne: {
             filter: {},
             update: {
+              $inc: {
+                bar: 123,
+              },
+              $set: {
+                foo: 'foo',
+              },
+            },
+            upsert: true,
+          },
+        },
+        {
+          updateOne: {
+            filter: {},
+            update: {
               $set: {
                 foo: 'foo',
               },
@@ -306,9 +320,22 @@ describe('model', () => {
                   bar: 123,
                   foo: 'foo',
                 },
-                $setOnInsert: {
-                  bar: 123456,
+                $setOnInsert: {},
+              },
+              upsert: true,
+            },
+          },
+          {
+            updateOne: {
+              filter: {},
+              update: {
+                $inc: {
+                  bar: 123,
                 },
+                $set: {
+                  foo: 'foo',
+                },
+                $setOnInsert: {},
               },
               upsert: true,
             },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -177,3 +177,21 @@ export function timestampBulkWriteOperation<TSchema>(
 
   return operation;
 }
+
+// Clean defaults if properties are present in $set, $push, $inc or $unset
+export function cleanSetOnInsert<TSchema>(
+  $setOnInsert: NonNullable<UpdateFilter<TSchema>['$setOnInsert']>,
+  update: UpdateFilter<TSchema>
+) {
+  for (const key of Object.keys($setOnInsert)) {
+    if (
+      key in (update.$set || {}) ||
+      key in (update.$push || {}) ||
+      key in (update.$inc || {}) ||
+      key in (update.$unset || {})
+    ) {
+      delete $setOnInsert[key];
+    }
+  }
+  return $setOnInsert;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -182,7 +182,7 @@ export function timestampBulkWriteOperation<TSchema>(
 export function cleanSetOnInsert<TSchema>(
   $setOnInsert: NonNullable<UpdateFilter<TSchema>['$setOnInsert']>,
   update: UpdateFilter<TSchema>
-) {
+): NonNullable<UpdateFilter<TSchema>['$setOnInsert']> {
   for (const key of Object.keys($setOnInsert)) {
     if (
       key in (update.$set || {}) ||


### PR DESCRIPTION
The fix in #41 did not account for fields that could be set in `$set`, `$inc`, `$unset` and `$push` - which can trigger conflicts errors.