### PR TITLE
Benchmark improvements

### DIFF
--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -35,13 +35,12 @@ const TIMES = {
 const NS_PER_S = 1e9;
 
 function timer() {
-  const time = process.hrtime();
+  const start = process.hrtime.bigint();
 
   return () => {
-    const diff = process.hrtime(time);
-    const ns = diff[0] * NS_PER_S + diff[1];
+    const diff = Number(process.hrtime.bigint() - start);
 
-    return Number(ns / NS_PER_S);
+    return diff / NS_PER_S;
   };
 }
 

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -3,7 +3,7 @@ import barChart from '@byu-oit/bar-chart';
 import { ObjectId } from 'mongodb';
 import SampleMongoose from './mongoose.js';
 import SamplePapr from './papr.js';
-import setup, { db } from './setup.js';
+import setup, { db, teardown } from './setup.js';
 
 const CHART_LABELS = ['insert', 'find', 'update'];
 const CHART_LEGEND_LABELS = ['mongodb', 'papr', 'mongoose'];
@@ -166,9 +166,8 @@ async function run() {
     .replace('font-family: "Helvetica Nue", Arial, sans-serif;', 'font-family: "Helvetica Nue", Arial, sans-serif; fill: #fff;');
 
   fs.writeFileSync('docs/benchmark.svg', chart);
-
-  process.exit(0);
 }
 
 await setup();
 await run();
+await teardown();

--- a/benchmark/setup.js
+++ b/benchmark/setup.js
@@ -61,3 +61,9 @@ export default async function setup() {
     directConnection: true
   });
 }
+
+export async function teardown() {
+  await db.dropDatabase();
+
+  process.exit(0);
+}


### PR DESCRIPTION
Just two small changes:

 - Updated benchmark to drop the test database after the run completes.
 - Converted the timer function to use `process.hrtime.bigint()` as recommended by the [Node.js docs](https://nodejs.org/api/process.html#process_process_hrtime_time).