### PR TITLE
docs: Fix docs about validation enums

### DIFF
--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -6,54 +6,25 @@ A schema is what defines a Model and the validation performed on the collection 
 
 ## `schema`
 
-Creates a schema for a model and define validation options for it.
-
-Read more about the validation [options](https://docs.mongodb.com/manual/core/schema-validation/index.html#behavior)
-in the MongoDB docs.
-
-Under the hood it is just a wrapper around the [`object`](api/types.md#object) type with some default properties
-(e.g. `_id` and timestamps properties).
-
-While the default `_id` property is added with an `ObjectId` type, its type can be customized into a `string` or a `number`
+Creates a schema for a model and define validation options for it.Read more about the validation [options](https://docs.mongodb.com/manual/core/schema-validation/index.html#behavior)in the MongoDB docs.Under the hood it is just a wrapper around the [`object`](api/types.md#object) type with some default properties(e.g. `_id` and timestamps properties).While the default `_id` property is added with an `ObjectId` type, its type can be customized into a `string` or a `number`
 
 **Parameters:**
 
-| Name                       | Type                      | Attribute |
-| -------------------------- | ------------------------- | --------- |
-| `properties`               | `Record<string, unknown>` | required  |
-| `options`                  | `SchemaOptions`           | optional  |
-| `options.defaults`         | `Partial<TProperties>`    | optional  |
-| `options.timestamps`       | `boolean`                 | optional  |
-| `options.validationAction` | `VALIDATION_ACTIONS`      | optional  |
-| `options.validationLevel`  | `VALIDATION_LEVEL`        | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `properties` | `Record<string, unknown>` | required |
+| `options` | `SchemaOptions` | optional |
+| `options.defaults` | `Partial<TProperties>` | optional |
+| `options.timestamps` | `boolean` | optional |
+| `options.validationAction` | `VALIDATION_ACTIONS` | optional |
+| `options.validationLevel` | `VALIDATION_LEVEL` | optional |
 
 **Returns:**
 
-`TSchema`
+`TSchema` 
 
 **Example:**
 
 ```ts
-import { schema, types, VALIDATION_ACTIONS, VALIDATION_LEVEL } from 'papr';
-
-const userSchema = schema({
-  active: types.boolean(),
-  age: types.number(),
-  firstName: types.string({ required: true }),
-  lastName: types.string({ required: true }),
-});
-
-const orderSchema = schema(
-  {
-    _id: types.number({ required: true }),
-    user: types.objectId({ required: true }),
-    product: types.string({ required: true }),
-  },
-  {
-    defaults: { product: 'test' },
-    timestamps: true,
-    validationAction: VALIDATION_ACTIONS.WARN,
-    validationLevel: VALIDATION_LEVEL.MODERATE,
-  }
-);
+import { schema, types, VALIDATION_ACTIONS, VALIDATION_LEVEL } from 'papr';const userSchema = schema({  active: types.boolean(),  age: types.number(),  firstName: types.string({ required: true }),  lastName: types.string({ required: true }),});const orderSchema = schema({  _id: types.number({ required: true }),  user: types.objectId({ required: true }),  product: types.string({ required: true })}, {  defaults: { product: 'test' },  timestamps: true,  validationAction: VALIDATION_ACTIONS.WARN,  validationLevel: VALIDATION_LEVEL.MODERATE});
 ```

--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -6,7 +6,15 @@ A schema is what defines a Model and the validation performed on the collection 
 
 ## `schema`
 
-Creates a schema for a model and define validation options for it.Read more about the validation [options](https://docs.mongodb.com/manual/core/schema-validation/index.html#behavior)in the MongoDB docs.Under the hood it is just a wrapper around the [`object`](api/types.md#object) type with some default properties(e.g. `_id` and timestamps properties).While the default `_id` property is added with an `ObjectId` type, its type can be customized into a `string` or a `number`
+Creates a schema for a model and define validation options for it.
+
+Read more about the validation [options](https://docs.mongodb.com/manual/core/schema-validation/index.html#behavior)
+in the MongoDB docs.
+
+Under the hood it is just a wrapper around the [`object`](api/types.md#object) type with some default properties
+(e.g. `_id` and timestamps properties).
+
+While the default `_id` property is added with an `ObjectId` type, its type can be customized into a `string` or a `number`
 
 **Parameters:**
 
@@ -26,5 +34,23 @@ Creates a schema for a model and define validation options for it.Read more ab
 **Example:**
 
 ```ts
-import { schema, types, VALIDATION_ACTIONS, VALIDATION_LEVEL } from 'papr';const userSchema = schema({  active: types.boolean(),  age: types.number(),  firstName: types.string({ required: true }),  lastName: types.string({ required: true }),});const orderSchema = schema({  _id: types.number({ required: true }),  user: types.objectId({ required: true }),  product: types.string({ required: true })}, {  defaults: { product: 'test' },  timestamps: true,  validationAction: VALIDATION_ACTIONS.WARN,  validationLevel: VALIDATION_LEVEL.MODERATE});
+import { schema, types, VALIDATION_ACTIONS, VALIDATION_LEVEL } from 'papr';
+
+const userSchema = schema({
+  active: types.boolean(),
+  age: types.number(),
+  firstName: types.string({ required: true }),
+  lastName: types.string({ required: true }),
+});
+
+const orderSchema = schema({
+  _id: types.number({ required: true }),
+  user: types.objectId({ required: true }),
+  product: types.string({ required: true })
+}, {
+  defaults: { product: 'test' },
+  timestamps: true,
+  validationAction: VALIDATION_ACTIONS.WARN,
+  validationLevel: VALIDATION_LEVEL.MODERATE
+});
 ```

--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -6,25 +6,54 @@ A schema is what defines a Model and the validation performed on the collection 
 
 ## `schema`
 
-Creates a schema for a model and define validation options for it.Read more about the validation [options](https://docs.mongodb.com/manual/core/schema-validation/index.html#behavior)in the MongoDB docs.Under the hood it is just a wrapper around the [`object`](api/types.md#object) type with some default properties(e.g. `_id` and timestamps properties).While the default `_id` property is added with an `ObjectId` type, its type can be customized into a `string` or a `number`
+Creates a schema for a model and define validation options for it.
+
+Read more about the validation [options](https://docs.mongodb.com/manual/core/schema-validation/index.html#behavior)
+in the MongoDB docs.
+
+Under the hood it is just a wrapper around the [`object`](api/types.md#object) type with some default properties
+(e.g. `_id` and timestamps properties).
+
+While the default `_id` property is added with an `ObjectId` type, its type can be customized into a `string` or a `number`
 
 **Parameters:**
 
-| Name | Type | Attribute |
-| --- | --- | --- |
-| `properties` | `Record<string, unknown>` | required |
-| `options` | `SchemaOptions` | optional |
-| `options.defaults` | `Partial<TProperties>` | optional |
-| `options.timestamps` | `boolean` | optional |
-| `options.validationAction` | `VALIDATION_ACTIONS` | optional |
-| `options.validationLevel` | `VALIDATION_LEVEL` | optional |
+| Name                       | Type                      | Attribute |
+| -------------------------- | ------------------------- | --------- |
+| `properties`               | `Record<string, unknown>` | required  |
+| `options`                  | `SchemaOptions`           | optional  |
+| `options.defaults`         | `Partial<TProperties>`    | optional  |
+| `options.timestamps`       | `boolean`                 | optional  |
+| `options.validationAction` | `VALIDATION_ACTIONS`      | optional  |
+| `options.validationLevel`  | `VALIDATION_LEVEL`        | optional  |
 
 **Returns:**
 
-`TSchema` 
+`TSchema`
 
 **Example:**
 
 ```ts
-import { schema, types, VALIDATION_ACTIONS, VALIDATION_LEVEL } from 'papr';const userSchema = schema({  active: types.boolean(),  age: types.number(),  firstName: types.string({ required: true }),  lastName: types.string({ required: true }),});const orderSchema = schema({  _id: types.number({ required: true }),  user: types.objectId({ required: true }),  product: types.string({ required: true })}, {  defaults: { product: 'test' },  timestamps: true,  validationAction: VALIDATION_ACTIONS.WARN,  validationLevel: VALIDATION_LEVEL.MODERATE});
+import { schema, types, VALIDATION_ACTIONS, VALIDATION_LEVEL } from 'papr';
+
+const userSchema = schema({
+  active: types.boolean(),
+  age: types.number(),
+  firstName: types.string({ required: true }),
+  lastName: types.string({ required: true }),
+});
+
+const orderSchema = schema(
+  {
+    _id: types.number({ required: true }),
+    user: types.objectId({ required: true }),
+    product: types.string({ required: true }),
+  },
+  {
+    defaults: { product: 'test' },
+    timestamps: true,
+    validationAction: VALIDATION_ACTIONS.WARN,
+    validationLevel: VALIDATION_LEVEL.MODERATE,
+  }
+);
 ```

--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -6,15 +6,7 @@ A schema is what defines a Model and the validation performed on the collection 
 
 ## `schema`
 
-Creates a schema for a model and define validation options for it.
-
-Read more about the validation [options](https://docs.mongodb.com/manual/core/schema-validation/index.html#behavior)
-in the MongoDB docs.
-
-Under the hood it is just a wrapper around the [`object`](api/types.md#object) type with some default properties
-(e.g. `_id` and timestamps properties).
-
-While the default `_id` property is added with an `ObjectId` type, its type can be customized into a `string` or a `number`
+Creates a schema for a model and define validation options for it.Read more about the validation [options](https://docs.mongodb.com/manual/core/schema-validation/index.html#behavior)in the MongoDB docs.Under the hood it is just a wrapper around the [`object`](api/types.md#object) type with some default properties(e.g. `_id` and timestamps properties).While the default `_id` property is added with an `ObjectId` type, its type can be customized into a `string` or a `number`
 
 **Parameters:**
 
@@ -24,7 +16,7 @@ While the default `_id` property is added with an `ObjectId` type, its type can 
 | `options` | `SchemaOptions` | optional |
 | `options.defaults` | `Partial<TProperties>` | optional |
 | `options.timestamps` | `boolean` | optional |
-| `options.validationAction` | `VALIDATION_ACTION` | optional |
+| `options.validationAction` | `VALIDATION_ACTIONS` | optional |
 | `options.validationLevel` | `VALIDATION_LEVEL` | optional |
 
 **Returns:**
@@ -34,23 +26,5 @@ While the default `_id` property is added with an `ObjectId` type, its type can 
 **Example:**
 
 ```ts
-import { schema, types } from 'papr';
-
-const userSchema = schema({
-  active: types.boolean(),
-  age: types.number(),
-  firstName: types.string({ required: true }),
-  lastName: types.string({ required: true }),
-});
-
-const orderSchema = schema({
-  _id: types.number({ required: true }),
-  user: types.objectId({ required: true }),
-  product: types.string({ required: true })
-}, {
-  defaults: { product: 'test' },
-  timestamps: true,
-  validationAction: VALIDATION_ACTION.WARN,
-  validationLevel: VALIDATION_LEVEL.MODERATE
-});
+import { schema, types, VALIDATION_ACTIONS, VALIDATION_LEVEL } from 'papr';const userSchema = schema({  active: types.boolean(),  age: types.number(),  firstName: types.string({ required: true }),  lastName: types.string({ required: true }),});const orderSchema = schema({  _id: types.number({ required: true }),  user: types.objectId({ required: true }),  product: types.string({ required: true })}, {  defaults: { product: 'test' },  timestamps: true,  validationAction: VALIDATION_ACTIONS.WARN,  validationLevel: VALIDATION_LEVEL.MODERATE});
 ```

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -60,13 +60,13 @@ function sanitize(value: any): void {
  * @param [options] {SchemaOptions}
  * @param [options.defaults] {Partial<TProperties>}
  * @param [options.timestamps=false] {boolean}
- * @param [options.validationAction=VALIDATION_ACTION.ERROR] {VALIDATION_ACTION}
+ * @param [options.validationAction=VALIDATION_ACTIONS.ERROR] {VALIDATION_ACTIONS}
  * @param [options.validationLevel=VALIDATION_LEVEL.STRICT] {VALIDATION_LEVEL}
  *
  * @returns {TSchema}
  *
  * @example
- * import { schema, types } from 'papr';
+ * import { schema, types, VALIDATION_ACTIONS, VALIDATION_LEVEL } from 'papr';
  *
  * const userSchema = schema({
  *   active: types.boolean(),
@@ -82,7 +82,7 @@ function sanitize(value: any): void {
  * }, {
  *   defaults: { product: 'test' },
  *   timestamps: true,
- *   validationAction: VALIDATION_ACTION.WARN,
+ *   validationAction: VALIDATION_ACTIONS.WARN,
  *   validationLevel: VALIDATION_LEVEL.MODERATE
  * });
  */


### PR DESCRIPTION
Two small fixes:

 - VALIDATION_ACTIONS and VALIDATION_LEVEL weren't being imported in the example
 - VALIDATION_ACTIONS was written as VALIDATION_ACTION