### PR TITLE
test: Use typescript v4.5

### DIFF
--- a/example/User.ts
+++ b/example/User.ts
@@ -1,4 +1,4 @@
-import { types, schema } from '../src';
+import { types, schema } from '../src/index.js';
 import papr from './papr';
 
 const userSchema = schema(

--- a/example/papr.ts
+++ b/example/papr.ts
@@ -1,5 +1,5 @@
 import { MongoClient } from 'mongodb';
-import Papr from '../src';
+import Papr from '../src/index.js';
 
 export let client: MongoClient;
 const papr = new Papr();

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "standard-version": "9.3.0",
     "ts-expect": "1.3.0",
     "ts-node": "10.3.0",
-    "typescript": "4.4.2"
+    "typescript": "beta"
   },
   "peerDependencies": {
     "mongodb": ">=4.1.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { Db } from 'mongodb';
-import { abstract, build, Model } from './model';
-import schema from './schema';
-import types from './types';
-import { BaseSchema, ModelOptions } from './utils';
+import { abstract, build, Model } from './model.js';
+import schema from './schema.js';
+import types from './types.js';
+import { BaseSchema, ModelOptions } from './utils.js';
 
 export default class Papr {
   db?: Db;

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,6 @@ export default class Papr {
 }
 
 export { schema, types, types as Types };
-export * from './hooks';
-export * from './model';
-export * from './utils';
+export * from './hooks.js';
+export * from './model.js';
+export * from './utils.js';

--- a/src/model.ts
+++ b/src/model.ts
@@ -22,7 +22,7 @@ import type {
   UpdateResult,
   WithId,
 } from 'mongodb';
-import { serializeArguments } from './hooks';
+import { serializeArguments } from './hooks.js';
 import {
   BaseSchema,
   cleanSetOnInsert,
@@ -31,7 +31,7 @@ import {
   ProjectionType,
   timestampBulkWriteOperation,
   timestampUpdateFilter,
-} from './utils';
+} from './utils.js';
 
 export interface Model<TSchema extends BaseSchema, TDefaults extends Partial<TSchema>> {
   collection: Collection<TSchema>;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,6 +1,6 @@
 import { WithId } from 'mongodb';
-import types, { ObjectType } from './types';
-import { TimestampSchema, VALIDATION_ACTIONS, VALIDATION_LEVEL } from './utils';
+import types, { ObjectType } from './types.js';
+import { TimestampSchema, VALIDATION_ACTIONS, VALIDATION_LEVEL } from './utils.js';
 
 interface SchemaOptions<TProperties, TDefaults extends Partial<TProperties>> {
   defaults?: TDefaults;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb';
 import type { AnyBulkWriteOperation, OptionalId, UpdateFilter } from 'mongodb';
-import { Hooks } from './hooks';
+import { Hooks } from './hooks.js';
 
 export enum VALIDATION_ACTIONS {
   ERROR = 'error',

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "module": "esnext",
+    "module": "nodenext",
     "noEmit": false,
     "outDir": "./esm",
-    "target": "esnext"
+    "target": "ESNext"
   },
   "extends": "./tsconfig.json",
   "include": ["./src"],

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "module": "ESNext",
+    "module": "esnext",
     "noEmit": false,
     "outDir": "./esm",
-    "target": "ESNext"
+    "target": "esnext"
   },
   "extends": "./tsconfig.json",
   "include": ["./src"],

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmit": false,
     "outDir": "./esm",
     "target": "ESNext"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "esModuleInterop": true,
     "lib": ["ES2020"],
     "module": "ESNext",
-    "moduleResolution": "Node",
     "noEmit": true,
     "noErrorTruncation": true,
     "noImplicitReturns": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "esModuleInterop": true,
     "lib": ["ES2020"],
     "module": "ESNext",
+    "moduleResolution": "Node",
     "noEmit": true,
     "noErrorTruncation": true,
     "noImplicitReturns": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7433,10 +7433,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
-  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
+typescript@beta:
+  version "4.5.0-beta"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.0-beta.tgz#f2e2724d93c35e7a0d0d1e55a22d1e4efb2181c7"
+  integrity sha512-7PvWhki2lwukaR9osVhFnNzxaE4LM+gC94dlwcvS+Tqz8+U65va7FbKo02bT+/MFlnMPM8bsPUXvHiMD/Mg3Jg==
 
 typical@^2.4.2, typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
- [x] upgraded `typescript` to `beta` (currently v4.5.0-beta) to try out the [new TS ESM features](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/)
- [x] added `.js` to all relative imports - this currently breaks `eslint` and `jest` :facepalm: 
- [ ] ~tried to use `"module": "node12"` like the blog mentions, but we get CommonJS syntax out instead of ESM :thinking: :bug:~ - https://github.com/microsoft/TypeScript/issues/46202 
- [x] use `"module": "nodenext"` for ESM build
- [ ] make `eslint` pass 
- [ ] make `jest` pass 