### PR TITLE
fix: ESM build with file extensions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# ESM
+
+tsc --project ./tsconfig-esm.json
+
+sed -i "s/from '.\/\(.*\)';/from '.\/\1.js';/g" ./esm/*.js
+
+# CommonJS
+
+tsc --project ./tsconfig-cjs.json
+
+echo "{\"type\":\"commonjs\"}" > ./cjs/package.json

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/plexinc/papr/issues/new"
   },
   "scripts": {
-    "build": "tsc --project ./tsconfig-esm.json && tsc --project ./tsconfig-cjs.json && echo \"{\\\"type\\\":\\\"commonjs\\\"}\" > ./cjs/package.json",
+    "build": "./build.sh",
     "docs": "node docs/build.js && docsify serve ./docs",
     "benchmark": "yarn build && node --experimental-specifier-resolution=node ./benchmark/run.js",
     "lint": "eslint --config ./.eslintrc.ts.json --ext .ts ./example ./src && eslint --ext .js,.mjs ./benchmark ./tests",

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -13,7 +13,7 @@ tar xf ./build/papr.tgz --directory=./build/
 cd tests/esm/
 rm -f package-lock.json
 npm install
-node --experimental-specifier-resolution=node ./index.js
+node ./index.js
 
 cd ../cjs/
 rm -f package-lock.json


### PR DESCRIPTION
Closes #121

This will update the ESM build and add file extensions to the imports, so that we don't need to use the `--experimental-specifier-resolution=node` flag.