### PR TITLE
fix: Support enum type with array of const values

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -114,7 +114,10 @@ schema({
 
 ## `enum`
 
-Creates an enum type based on a TypeScript `enum` structure.
+With `enum` you can either :
+
+- Create an enum type based on a TypeScript `enum` structure
+- Create an union type based on an array of `const`
 
 Enum types may contain `null` as well.
 
@@ -140,6 +143,8 @@ schema({
   requiredEnum: types.enum(Object.values(Sample), { required: true }),
   optionalEnum: types.enum(Object.values(Sample)),
   optionalEnumWithNull: types.enum([...Object.values(Sample), null]),
+  optionalEnumAsConstArray: types.enum(['foo' as const, 'bar' as const], { required: true }), // type is 'foo' | 'bar' | undefined
+  requiredEnumAsConstArray: types.enum(['foo' as const, 'bar' as const], { required: true }), // type is 'foo' | 'bar'
 });
 ```
 

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -103,6 +103,18 @@ describe('types', () => {
         // @ts-expect-error invalid option
         types.enum(Object.values(TEST_ENUM), { maxLength: 1 });
       });
+
+      test('array of const', () => {
+        const value = types.enum(['a' as const, 'b' as const]);
+
+        expect(value).toEqual({
+          enum: ['a', 'b'],
+        });
+        expectType<typeof value>('a');
+        // @ts-expect-error `value` can not be c
+        expectType<typeof value>('c');
+        expectType<typeof value>(undefined);
+      });
     });
 
     describe('number', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,7 +285,10 @@ export default {
   date: createSimpleType<Date>('date'),
 
   /**
-   * Creates an enum type based on a TypeScript `enum` structure.
+   * With `enum` you can either :
+   *
+   * - Create an enum type based on a TypeScript `enum` structure
+   * - Create an union type based on an array of `const`
    *
    * Enum types may contain `null` as well.
    *
@@ -305,6 +308,8 @@ export default {
    *   requiredEnum: types.enum(Object.values(Sample), { required: true }),
    *   optionalEnum: types.enum(Object.values(Sample)),
    *   optionalEnumWithNull: types.enum([...Object.values(Sample), null]),
+   *   optionalEnumAsConstArray: types.enum(['foo' as const, 'bar' as const], { required: true }), // type is 'foo' | 'bar' | undefined
+   *   requiredEnumAsConstArray: types.enum(['foo' as const, 'bar' as const], { required: true }), // type is 'foo' | 'bar'
    * });
    */
   enum: enumType,


### PR DESCRIPTION
In my case, I want to avoid the usage of enum, replaced by union type.

I found out that `papr` works natively fine in this case :)

I just added a test on it and a piece of documentation.

Thx a lot for your lib btw :) 

```ts
tt: types.enum(
              [
                'FOO' as const,
                'BAR' as const,
              ],
              { required: true },
            ),
```

resolves as `'FOO' | 'BAR'`