### PR TITLE
feat: Accepts string in enum types

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -22,10 +22,10 @@ Calls the MongoDB [`aggregate()`](https://mongodb.github.io/node-mongodb-native/
 
 **Parameters:**
 
-| Name       | Type                             | Attribute |
-| ---------- | -------------------------------- | --------- |
-| `pipeline` | `Array<Record<string, unknown>>` | required  |
-| `options`  | `AggregateOptions`               | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `pipeline` | `Array<Record<string, unknown>>` | required |
+| `options` | `AggregateOptions` | optional |
 
 **Returns:**
 
@@ -34,8 +34,12 @@ Calls the MongoDB [`aggregate()`](https://mongodb.github.io/node-mongodb-native/
 **Example:**
 
 ```ts
-const results = await User.aggregate([{ $sortByCount: '$age' }, { $limit: 5 }]);
+const results = await User.aggregate([
+ { $sortByCount: '$age' },
+ { $limit: 5 }
+]);
 ```
+
 
 ## `bulkWrite`
 
@@ -43,10 +47,10 @@ Calls the MongoDB [`bulkWrite()`](https://mongodb.github.io/node-mongodb-native/
 
 **Parameters:**
 
-| Name         | Type                                    | Attribute |
-| ------------ | --------------------------------------- | --------- |
-| `operations` | `Array<AnyBulkWriteOperation<TSchema>>` | required  |
-| `options`    | `BulkWriteOptions`                      | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `operations` | `Array<AnyBulkWriteOperation<TSchema>>` | required |
+| `options` | `BulkWriteOptions` | optional |
 
 **Returns:**
 
@@ -56,24 +60,25 @@ Calls the MongoDB [`bulkWrite()`](https://mongodb.github.io/node-mongodb-native/
 
 ```ts
 const results = await User.bulkWrite([
-  {
-    insertOne: {
-      document: {
-        firstName: 'John',
-        lastName: 'Wick',
-      },
-    },
-  },
-  {
-    updateOne: {
-      filter: { lastName: 'Wick' },
-      update: {
-        $set: { age: 40 },
-      },
-    },
-  },
+   {
+     insertOne: {
+       document: {
+         firstName: 'John',
+         lastName: 'Wick'
+       },
+     },
+   },
+   {
+     updateOne: {
+       filter: { lastName: 'Wick' },
+       update: {
+         $set: { age: 40 },
+       },
+     },
+   },
 ]);
 ```
+
 
 ## `countDocuments`
 
@@ -81,14 +86,14 @@ Calls the MongoDB [`countDocuments()`](https://mongodb.github.io/node-mongodb-na
 
 **Parameters:**
 
-| Name      | Type                    | Attribute |
-| --------- | ----------------------- | --------- |
-| `filter`  | `Filter<TSchema>`       | required  |
-| `options` | `CountDocumentsOptions` | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `filter` | `Filter<TSchema>` | required |
+| `options` | `CountDocumentsOptions` | optional |
 
 **Returns:**
 
-`Promise<number>`
+`Promise<number>` 
 
 **Example:**
 
@@ -97,16 +102,17 @@ const countAll = await User.countDocuments({});
 const countWicks = await User.countDocuments({ lastName: 'Wick' });
 ```
 
+
 ## `deleteMany`
 
 Calls the MongoDB [`deleteMany()`](https://mongodb.github.io/node-mongodb-native/4.1/classes/Collection.html#deleteMany) method.
 
 **Parameters:**
 
-| Name      | Type              | Attribute |
-| --------- | ----------------- | --------- |
-| `filter`  | `Filter<TSchema>` | required  |
-| `options` | `DeleteOptions`   | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `filter` | `Filter<TSchema>` | required |
+| `options` | `DeleteOptions` | optional |
 
 **Returns:**
 
@@ -118,16 +124,17 @@ Calls the MongoDB [`deleteMany()`](https://mongodb.github.io/node-mongodb-native
 await User.deleteMany({ lastName: 'Wick' });
 ```
 
+
 ## `deleteOne`
 
 Calls the MongoDB [`deleteOne()`](https://mongodb.github.io/node-mongodb-native/4.1/classes/Collection.html#deleteOne) method.
 
 **Parameters:**
 
-| Name      | Type              | Attribute |
-| --------- | ----------------- | --------- |
-| `filter`  | `Filter<TSchema>` | required  |
-| `options` | `DeleteOptions`   | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `filter` | `Filter<TSchema>` | required |
+| `options` | `DeleteOptions` | optional |
 
 **Returns:**
 
@@ -139,17 +146,18 @@ Calls the MongoDB [`deleteOne()`](https://mongodb.github.io/node-mongodb-native/
 await User.deleteOne({ lastName: 'Wick' });
 ```
 
+
 ## `distinct`
 
 Calls the MongoDB [`distinct()`](https://mongodb.github.io/node-mongodb-native/4.1/classes/Collection.html#distinct) method.
 
 **Parameters:**
 
-| Name      | Type              | Attribute |
-| --------- | ----------------- | --------- |
-| `key`     | `keyof TSchema`   | required  |
-| `filter`  | `Filter<TSchema>` | optional  |
-| `options` | `DistinctOptions` | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `key` | `keyof TSchema` | required |
+| `filter` | `Filter<TSchema>` | optional |
+| `options` | `DistinctOptions` | optional |
 
 **Returns:**
 
@@ -161,6 +169,7 @@ Calls the MongoDB [`distinct()`](https://mongodb.github.io/node-mongodb-native/4
 const ages = await User.distinct('age');
 ```
 
+
 ## `find`
 
 Calls the MongoDB [`find()`](https://mongodb.github.io/node-mongodb-native/4.1/classes/Collection.html#find) method.
@@ -169,14 +178,14 @@ The result type (`TProjected`) takes into account the projection for this query 
 
 **Parameters:**
 
-| Name      | Type                   | Attribute |
-| --------- | ---------------------- | --------- |
-| `filter`  | `Filter<TSchema>`      | required  |
-| `options` | `FindOptions<TSchema>` | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `filter` | `Filter<TSchema>` | required |
+| `options` | `FindOptions<TSchema>` | optional |
 
 **Returns:**
 
-`Promise<Array<TProjected>>`
+`Promise<Array<TProjected>>` 
 
 **Example:**
 
@@ -185,10 +194,14 @@ const users = await User.find({ firstName: 'John' });
 users[0]?.firstName; // valid
 users[0]?.lastName; // valid
 
-const usersProjected = await User.find({ firstName: 'John' }, { projection: { lastName: 1 } });
+const usersProjected = await User.find(
+  { firstName: 'John' },
+  { projection: { lastName: 1 } }
+);
 usersProjected[0]?.firstName; // TypeScript error
 usersProjected[0]?.lastName; // valid
 ```
+
 
 ## `findById`
 
@@ -198,14 +211,14 @@ The result type (`TProjected`) takes into account the projection for this query 
 
 **Parameters:**
 
-| Name      | Type                   | Attribute |
-| --------- | ---------------------- | --------- |
-| `id`      | `string \| ObjectId`   | required  |
-| `options` | `FindOptions<TSchema>` | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `id` | `string \| ObjectId` | required |
+| `options` | `FindOptions<TSchema>` | optional |
 
 **Returns:**
 
-`Promise<(TProjected | null)>`
+`Promise<(TProjected | null)>` 
 
 **Example:**
 
@@ -214,12 +227,14 @@ const user = await User.findById('606ac819fa14e243e66ec4f4');
 user.firstName; // valid
 user.lastName; // valid
 
-const userProjected = await User.find(new ObjectId('606ac819fa14e243e66ec4f4'), {
-  projection: { lastName: 1 },
-});
+const userProjected = await User.find(
+  new ObjectId('606ac819fa14e243e66ec4f4'),
+  { projection: { lastName: 1 } }
+);
 userProjected.firstName; // TypeScript error
 userProjected.lastName; // valid
 ```
+
 
 ## `findOne`
 
@@ -229,14 +244,14 @@ The result type (`TProjected`) takes into account the projection for this query 
 
 **Parameters:**
 
-| Name      | Type                   | Attribute |
-| --------- | ---------------------- | --------- |
-| `filter`  | `Filter<TSchema>`      | required  |
-| `options` | `FindOptions<TSchema>` | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `filter` | `Filter<TSchema>` | required |
+| `options` | `FindOptions<TSchema>` | optional |
 
 **Returns:**
 
-`Promise<(TProjected | null)>`
+`Promise<(TProjected | null)>` 
 
 **Example:**
 
@@ -245,10 +260,14 @@ const user = await User.findOne({ firstName: 'John' });
 user.firstName; // valid
 user.lastName; // valid
 
-const userProjected = await User.findOne({ firstName: 'John' }, { projection: { lastName: 1 } });
+const userProjected = await User.findOne(
+  { firstName: 'John' },
+  { projection: { lastName: 1 } }
+);
 userProjected.firstName; // TypeScript error
 userProjected.lastName; // valid
 ```
+
 
 ## `findOneAndDelete`
 
@@ -258,20 +277,21 @@ The result type (`TProjected`) takes into account the projection for this query 
 
 **Parameters:**
 
-| Name      | Type                      | Attribute |
-| --------- | ------------------------- | --------- |
-| `filter`  | `Filter<TSchema>`         | required  |
-| `options` | `FindOneAndUpdateOptions` | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `filter` | `Filter<TSchema>` | required |
+| `options` | `FindOneAndUpdateOptions` | optional |
 
 **Returns:**
 
-`Promise<(TProjected | null)>`
+`Promise<(TProjected | null)>` 
 
 **Example:**
 
 ```ts
 const user = await User.findOneAndDelete({ firstName: 'John' });
 ```
+
 
 ## `findOneAndUpdate`
 
@@ -281,20 +301,23 @@ The result type (`TProjected`) takes into account the projection for this query 
 
 **Parameters:**
 
-| Name      | Type                      | Attribute |
-| --------- | ------------------------- | --------- |
-| `filter`  | `Filter<TSchema>`         | required  |
-| `update`  | `UpdateFilter<TSchema>`   | required  |
-| `options` | `FindOneAndUpdateOptions` | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `filter` | `Filter<TSchema>` | required |
+| `update` | `UpdateFilter<TSchema>` | required |
+| `options` | `FindOneAndUpdateOptions` | optional |
 
 **Returns:**
 
-`Promise<(TProjected | null)>`
+`Promise<(TProjected | null)>` 
 
 **Example:**
 
 ```ts
-const user = await User.findOneAndUpdate({ firstName: 'John' }, { $set: { age: 40 } });
+const user = await User.findOneAndUpdate(
+  { firstName: 'John' },
+  { $set: { age: 40 } }
+);
 user.firstName; // valid
 user.lastName; // valid
 
@@ -307,29 +330,31 @@ userProjected.firstName; // TypeScript error
 userProjected.lastName; // valid
 ```
 
+
 ## `insertMany`
 
 Calls the MongoDB [`insertMany()`](https://mongodb.github.io/node-mongodb-native/4.1/classes/Collection.html#insertMany) method.
 
 **Parameters:**
 
-| Name        | Type               | Attribute |
-| ----------- | ------------------ | --------- |
-| `documents` | `Array<TSchema>`   | required  |
-| `options`   | `BulkWriteOptions` | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `documents` | `Array<TSchema>` | required |
+| `options` | `BulkWriteOptions` | optional |
 
 **Returns:**
 
-`Promise<Array<TSchema>>`
+`Promise<Array<TSchema>>` 
 
 **Example:**
 
 ```ts
 const users = await User.insertMany([
   { firstName: 'John', lastName: 'Wick' },
-  { firstName: 'John', lastName: 'Doe' },
+  { firstName: 'John', lastName: 'Doe' }
 ]);
 ```
+
 
 ## `insertOne`
 
@@ -337,23 +362,24 @@ Calls the MongoDB [`insertOne()`](https://mongodb.github.io/node-mongodb-native/
 
 **Parameters:**
 
-| Name       | Type               | Attribute |
-| ---------- | ------------------ | --------- |
-| `document` | `TSchema`          | required  |
-| `options`  | `InsertOneOptions` | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `document` | `TSchema` | required |
+| `options` | `InsertOneOptions` | optional |
 
 **Returns:**
 
-`Promise<TSchema>`
+`Promise<TSchema>` 
 
 **Example:**
 
 ```ts
 const users = await User.insertOne([
   { firstName: 'John', lastName: 'Wick' },
-  { firstName: 'John', lastName: 'Doe' },
+  { firstName: 'John', lastName: 'Doe' }
 ]);
 ```
+
 
 ## `updateMany`
 
@@ -361,11 +387,11 @@ Calls the MongoDB [`updateMany()`](https://mongodb.github.io/node-mongodb-native
 
 **Parameters:**
 
-| Name      | Type                    | Attribute |
-| --------- | ----------------------- | --------- |
-| `filter`  | `Filter<TSchema>`       | required  |
-| `update`  | `UpdateFilter<TSchema>` | required  |
-| `options` | `UpdateOptions`         | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `filter` | `Filter<TSchema>` | required |
+| `update` | `UpdateFilter<TSchema>` | required |
+| `options` | `UpdateOptions` | optional |
 
 **Returns:**
 
@@ -374,8 +400,12 @@ Calls the MongoDB [`updateMany()`](https://mongodb.github.io/node-mongodb-native
 **Example:**
 
 ```ts
-const result = await User.updateMany({ firstName: 'John' }, { $set: { age: 40 } });
+const result = await User.updateMany(
+  { firstName: 'John' },
+  { $set: { age: 40 } }
+);
 ```
+
 
 ## `updateOne`
 
@@ -383,11 +413,11 @@ Calls the MongoDB [`updateOne()`](https://mongodb.github.io/node-mongodb-native/
 
 **Parameters:**
 
-| Name      | Type                    | Attribute |
-| --------- | ----------------------- | --------- |
-| `filter`  | `Filter<TSchema>`       | required  |
-| `update`  | `UpdateFilter<TSchema>` | required  |
-| `options` | `UpdateOptions`         | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `filter` | `Filter<TSchema>` | required |
+| `update` | `UpdateFilter<TSchema>` | required |
+| `options` | `UpdateOptions` | optional |
 
 **Returns:**
 
@@ -396,8 +426,12 @@ Calls the MongoDB [`updateOne()`](https://mongodb.github.io/node-mongodb-native/
 **Example:**
 
 ```ts
-const result = await User.updateOne({ firstName: 'John' }, { $set: { age: 40 } });
+const result = await User.updateOne(
+  { firstName: 'John' },
+  { $set: { age: 40 } }
+);
 ```
+
 
 ## `upsert`
 
@@ -405,17 +439,20 @@ Calls the MongoDB [`findOneAndUpdate()`](https://mongodb.github.io/node-mongodb-
 
 **Parameters:**
 
-| Name     | Type                    | Attribute |
-| -------- | ----------------------- | --------- |
-| `filter` | `Filter<TSchema>`       | required  |
-| `update` | `UpdateFilter<TSchema>` | required  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `filter` | `Filter<TSchema>` | required |
+| `update` | `UpdateFilter<TSchema>` | required |
 
 **Returns:**
 
-`Promise<TSchema>`
+`Promise<TSchema>` 
 
 **Example:**
 
 ```ts
-const user = await User.upsert({ firstName: 'John', lastName: 'Wick' }, { $set: { age: 40 } });
+const user = await User.upsert(
+  { firstName: 'John', lastName: 'Wick' },
+  { $set: { age: 40 } }
+);
 ```

--- a/docs/api/papr.md
+++ b/docs/api/papr.md
@@ -2,6 +2,8 @@
 
 # Papr
 
+
+
 ## `Papr`
 
 Returns a new instance of `Papr`.
@@ -10,11 +12,11 @@ It may be called with some options for before and after hooks and a maximum exec
 
 **Parameters:**
 
-| Name              | Type           | Attribute |
-| ----------------- | -------------- | --------- |
-| `options`         | `ModelOptions` | optional  |
-| `options.hooks`   | `Hooks`        | optional  |
-| `options.maxTime` | `number`       | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `options` | `ModelOptions` | optional |
+| `options.hooks` | `Hooks` | optional |
+| `options.maxTime` | `number` | optional |
 
 **Example:**
 
@@ -24,11 +26,12 @@ const papr = new Papr();
 const paprWithOptions = new Papr({
   hooks: {
     after: [afterHook],
-    before: [beforeHook],
+    before: [beforeHook]
   },
-  maxTime: 1000,
+  maxTime: 1000
 });
 ```
+
 
 ## `initialize`
 
@@ -36,9 +39,9 @@ Initialize existing and future registered models with a mongo db instance
 
 **Parameters:**
 
-| Name | Type         | Attribute |
-| ---- | ------------ | --------- |
-| `db` | `mongodb.Db` | required  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `db` | `mongodb.Db` | required |
 
 **Example:**
 
@@ -50,26 +53,28 @@ const connection = await MongoClient.connect('mongodb://localhost:27017');
 papr.initialize(connection.db('test'));
 ```
 
+
 ## `model`
 
 Builds a model instance and associates its collection name and schema.
 
 **Parameters:**
 
-| Name               | Type      | Attribute |
-| ------------------ | --------- | --------- |
-| `collectionName`   | `string`  | required  |
-| `collectionSchema` | `TSchema` | required  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `collectionName` | `string` | required |
+| `collectionSchema` | `TSchema` | required |
 
 **Returns:**
 
-`Model<TSchema, TDefaults>`
+`Model<TSchema, TDefaults>` 
 
 **Example:**
 
 ```ts
 const User = papr.model('users', userSchema);
 ```
+
 
 ## `updateSchema`
 
@@ -81,13 +86,13 @@ command for existing collections.
 
 **Parameters:**
 
-| Name    | Type                        | Attribute |
-| ------- | --------------------------- | --------- |
-| `model` | `Model<TSchema, TDefaults>` | required  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `model` | `Model<TSchema, TDefaults>` | required |
 
 **Returns:**
 
-`Promise<void>`
+`Promise<void>` 
 
 **Example:**
 
@@ -95,13 +100,14 @@ command for existing collections.
 await papr.updateSchema(User);
 ```
 
+
 ## `updateSchemas`
 
 Updates the validation schemas and validation options on all the MongoDB collections registered by models.
 
 **Returns:**
 
-`Promise<void>`
+`Promise<void>` 
 
 **Example:**
 

--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -18,14 +18,14 @@ While the default `_id` property is added with an `ObjectId` type, its type can 
 
 **Parameters:**
 
-| Name                       | Type                      | Attribute |
-| -------------------------- | ------------------------- | --------- |
-| `properties`               | `Record<string, unknown>` | required  |
-| `options`                  | `SchemaOptions`           | optional  |
-| `options.defaults`         | `Partial<TProperties>`    | optional  |
-| `options.timestamps`       | `boolean`                 | optional  |
-| `options.validationAction` | `VALIDATION_ACTIONS`      | optional  |
-| `options.validationLevel`  | `VALIDATION_LEVEL`        | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `properties` | `Record<string, unknown>` | required |
+| `options` | `SchemaOptions` | optional |
+| `options.defaults` | `Partial<TProperties>` | optional |
+| `options.timestamps` | `boolean` | optional |
+| `options.validationAction` | `VALIDATION_ACTIONS` | optional |
+| `options.validationLevel` | `VALIDATION_LEVEL` | optional |
 
 **Returns:**
 
@@ -45,19 +45,16 @@ const userSchema = schema({
 
 type UserDocument = typeof userSchema[0];
 
-const orderSchema = schema(
-  {
-    _id: types.number({ required: true }),
-    user: types.objectId({ required: true }),
-    product: types.string({ required: true }),
-  },
-  {
-    defaults: { product: 'test' },
-    timestamps: true,
-    validationAction: VALIDATION_ACTIONS.WARN,
-    validationLevel: VALIDATION_LEVEL.MODERATE,
-  }
-);
+const orderSchema = schema({
+  _id: types.number({ required: true }),
+  user: types.objectId({ required: true }),
+  product: types.string({ required: true })
+}, {
+  defaults: { product: 'test' },
+  timestamps: true,
+  validationAction: VALIDATION_ACTIONS.WARN,
+  validationLevel: VALIDATION_LEVEL.MODERATE
+});
 
 type OrderDocument = typeof orderSchema[0];
 ```

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -16,14 +16,14 @@ Creates an array consisting of items of a single type.
 
 **Parameters:**
 
-| Name                  | Type           | Attribute |
-| --------------------- | -------------- | --------- |
-| `item`                | `TItem`        | required  |
-| `options`             | `ArrayOptions` | optional  |
-| `options.maxItems`    | `number`       | optional  |
-| `options.minItems`    | `number`       | optional  |
-| `options.required`    | `boolean`      | optional  |
-| `options.uniqueItems` | `boolean`      | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `item` | `TItem` | required |
+| `options` | `ArrayOptions` | optional |
+| `options.maxItems` | `number` | optional |
+| `options.minItems` | `number` | optional |
+| `options.required` | `boolean` | optional |
+| `options.uniqueItems` | `boolean` | optional |
 
 **Example:**
 
@@ -42,16 +42,17 @@ schema({
 });
 ```
 
+
 ## `binary`
 
 Creates a binary type. Useful for storing `Buffer` or any other binary data.
 
 **Parameters:**
 
-| Name               | Type             | Attribute |
-| ------------------ | ---------------- | --------- |
-| `options`          | `GenericOptions` | optional  |
-| `options.required` | `boolean`        | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `options` | `GenericOptions` | optional |
+| `options.required` | `boolean` | optional |
 
 **Example:**
 
@@ -64,16 +65,17 @@ schema({
 });
 ```
 
+
 ## `boolean`
 
 Creates a boolean type.
 
 **Parameters:**
 
-| Name               | Type             | Attribute |
-| ------------------ | ---------------- | --------- |
-| `options`          | `GenericOptions` | optional  |
-| `options.required` | `boolean`        | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `options` | `GenericOptions` | optional |
+| `options.required` | `boolean` | optional |
 
 **Example:**
 
@@ -86,16 +88,17 @@ schema({
 });
 ```
 
+
 ## `date`
 
 Creates a date type.
 
 **Parameters:**
 
-| Name               | Type             | Attribute |
-| ------------------ | ---------------- | --------- |
-| `options`          | `GenericOptions` | optional  |
-| `options.required` | `boolean`        | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `options` | `GenericOptions` | optional |
+| `options.required` | `boolean` | optional |
 
 **Example:**
 
@@ -108,22 +111,24 @@ schema({
 });
 ```
 
+
 ## `enum`
 
 With `enum` you can create an enum type either:
 
 - based on a TypeScript `enum` structure
 - based on an array of `const`
+- based on an array of litteral strings
 
 Enum types may contain `null` as well.
 
 **Parameters:**
 
-| Name               | Type             | Attribute |
-| ------------------ | ---------------- | --------- |
-| `values`           | `Array<TValue>`  | required  |
-| `options`          | `GenericOptions` | optional  |
-| `options.required` | `boolean`        | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `values` | `Array<TValue>` | required |
+| `options` | `GenericOptions` | optional |
+| `options.required` | `boolean` | optional |
 
 **Example:**
 
@@ -132,7 +137,7 @@ import { schema, types } from 'papr';
 
 enum SampleEnum {
   foo = 'foo',
-  bar = 'bar',
+  bar = 'bar'
 }
 
 const SampleArray = ['foo' as const, 'bar' as const];
@@ -148,8 +153,13 @@ schema({
   requiredEnumAsConstArray: types.enum(SampleArray, { required: true }),
   // type: 'foo' | 'bar' | undefined
   optionalEnumAsConstArray: types.enum(SampleArray),
+  // type: 'foo' | 'bar'
+  requiredEnumAsStringLitteralArray: types.enum(['foo', 'bar'], { required: true }),
+  // type: 'foo' | 'bar' | undefined
+  optionalEnumAsStringLitteralArray: types.enum(['foo', 'bar']),
 });
 ```
+
 
 ## `number`
 
@@ -157,16 +167,16 @@ Creates a number type.
 
 **Parameters:**
 
-| Name                       | Type            | Attribute |
-| -------------------------- | --------------- | --------- |
-| `options`                  | `NumberOptions` | optional  |
-| `options.enum`             | `Array<number>` | optional  |
-| `options.exclusiveMaximum` | `boolean`       | optional  |
-| `options.exclusiveMinimum` | `boolean`       | optional  |
-| `options.maximum`          | `number`        | optional  |
-| `options.minimum`          | `number`        | optional  |
-| `options.mulitpleOf`       | `number`        | optional  |
-| `options.required`         | `boolean`       | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `options` | `NumberOptions` | optional |
+| `options.enum` | `Array<number>` | optional |
+| `options.exclusiveMaximum` | `boolean` | optional |
+| `options.exclusiveMinimum` | `boolean` | optional |
+| `options.maximum` | `number` | optional |
+| `options.minimum` | `number` | optional |
+| `options.mulitpleOf` | `number` | optional |
+| `options.required` | `boolean` | optional |
 
 **Example:**
 
@@ -188,22 +198,23 @@ schema({
 });
 ```
 
+
 ## `object`
 
 Creates an object type specifying all the known properties upfront.
 
 **Parameters:**
 
-| Name                           | Type                            | Attribute |
-| ------------------------------ | ------------------------------- | --------- |
-| `properties`                   | `TProperties`                   | required  |
-| `options`                      | `ObjectOptions`                 | optional  |
-| `options.additionalProperties` | `boolean`                       | optional  |
-| `options.dependencies`         | `Record<string, Array<string>>` | optional  |
-| `options.maxProperties`        | `number`                        | optional  |
-| `options.minProperties`        | `number`                        | optional  |
-| `options.patternProperties`    | `Record<string, unknown>`       | optional  |
-| `options.required`             | `boolean`                       | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `properties` | `TProperties` | required |
+| `options` | `ObjectOptions` | optional |
+| `options.additionalProperties` | `boolean` | optional |
+| `options.dependencies` | `Record<string, Array<string>>` | optional |
+| `options.maxProperties` | `number` | optional |
+| `options.minProperties` | `number` | optional |
+| `options.patternProperties` | `Record<string, unknown>` | optional |
+| `options.required` | `boolean` | optional |
 
 **Example:**
 
@@ -243,22 +254,23 @@ schema({
 });
 ```
 
+
 ## `objectGeneric`
 
 Creates an object type without any upfront properties defined, instead you define only a pattern for the properties names. All properties will expect the same type as value (`TValue`).
 
 **Parameters:**
 
-| Name                           | Type                            | Attribute |
-| ------------------------------ | ------------------------------- | --------- |
-| `value`                        | `TValue`                        | required  |
-| `pattern`                      | `string`                        | optional  |
-| `options`                      | `ObjectOptions`                 | optional  |
-| `options.additionalProperties` | `boolean`                       | optional  |
-| `options.dependencies`         | `Record<string, Array<string>>` | optional  |
-| `options.maxProperties`        | `number`                        | optional  |
-| `options.minProperties`        | `number`                        | optional  |
-| `options.required`             | `boolean`                       | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `value` | `TValue` | required |
+| `pattern` | `string` | optional |
+| `options` | `ObjectOptions` | optional |
+| `options.additionalProperties` | `boolean` | optional |
+| `options.dependencies` | `Record<string, Array<string>>` | optional |
+| `options.maxProperties` | `number` | optional |
+| `options.minProperties` | `number` | optional |
+| `options.required` | `boolean` | optional |
 
 **Example:**
 
@@ -269,9 +281,14 @@ schema({
   // This accepts any property name with the value as a number
   optionalObjectGeneric: types.objectGeneric(types.number()),
   // This accepts only objects with properties starting with `foo`
-  requiredObjectGeneric: types.objectGeneric(types.number(), '^foo.+', { required: true }),
+  requiredObjectGeneric: types.objectGeneric(
+    types.number(),
+    '^foo.+',
+    { required: true }
+  ),
 });
 ```
+
 
 ## `objectId`
 
@@ -279,10 +296,10 @@ Creates an `ObjectId` type.
 
 **Parameters:**
 
-| Name               | Type             | Attribute |
-| ------------------ | ---------------- | --------- |
-| `options`          | `GenericOptions` | optional  |
-| `options.required` | `boolean`        | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `options` | `GenericOptions` | optional |
+| `options.required` | `boolean` | optional |
 
 **Example:**
 
@@ -295,20 +312,21 @@ schema({
 });
 ```
 
+
 ## `string`
 
 Creates a string type.
 
 **Parameters:**
 
-| Name                | Type            | Attribute |
-| ------------------- | --------------- | --------- |
-| `options`           | `StringOptions` | optional  |
-| `options.enum`      | `Array<string>` | optional  |
-| `options.maxLength` | `number`        | optional  |
-| `options.minLength` | `number`        | optional  |
-| `options.pattern`   | `string`        | optional  |
-| `options.required`  | `boolean`       | optional  |
+| Name | Type | Attribute |
+| --- | --- | --- |
+| `options` | `StringOptions` | optional |
+| `options.enum` | `Array<string>` | optional |
+| `options.maxLength` | `number` | optional |
+| `options.minLength` | `number` | optional |
+| `options.pattern` | `string` | optional |
+| `options.required` | `boolean` | optional |
 
 **Example:**
 
@@ -327,6 +345,7 @@ schema({
   }),
 });
 ```
+
 
 ## `any`
 

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -10,7 +10,7 @@ This TypeScript type is useful to compute the sub-document resulting from a `fin
 import { ProjectionType } from 'papr';
 
 const projection = {
-  firstName: 1,
+  firstName: 1
 };
 
 type UserProjected = ProjectionType<UserDocument, typeof projection>;
@@ -39,3 +39,4 @@ enum VALIDATION_LEVEL {
   STRICT = 'strict',
 }
 ```
+

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -105,15 +105,52 @@ describe('types', () => {
       });
 
       test('array of const', () => {
-        const value = types.enum(['a' as const, 'b' as const]);
+        const valueRequired = types.enum(['a' as const, 'b' as const], { required: true });
+        const valueNonRequired = types.enum(['a' as const, 'b' as const]);
 
-        expect(value).toEqual({
+        expect(valueRequired).toEqual({
+          $required: true,
           enum: ['a', 'b'],
         });
-        expectType<typeof value>('a');
+        expect(valueNonRequired).toEqual({
+          enum: ['a', 'b'],
+        });
+        expectType<typeof valueRequired>('a');
+        // @ts-expect-error `valueRequired` can not be c
+        expectType<typeof valueRequired>('c');
+        // @ts-expect-error `valueRequired` can not be undefined
+        expectType<typeof valueRequired>(undefined);
+
+        expectType<typeof valueNonRequired>('a');
         // @ts-expect-error `value` can not be c
-        expectType<typeof value>('c');
-        expectType<typeof value>(undefined);
+        expectType<typeof valueNonRequired>('c');
+        expectType<typeof valueNonRequired>(undefined);
+      });
+
+      test('array of strings', () => {
+        const valueRequired = types.enum(['a', 'b'], { required: true });
+        const valueNonRequired = types.enum(['a', 'b']);
+        const arrayOfStrings = ['a', 'b'];
+        // @ts-expect-error accepts only litterals
+        types.enum(arrayOfStrings);
+
+        expect(valueRequired).toEqual({
+          $required: true,
+          enum: ['a', 'b'],
+        });
+        expect(valueNonRequired).toEqual({
+          enum: ['a', 'b'],
+        });
+        expectType<typeof valueRequired>('a');
+        // @ts-expect-error `valueRequired` can not be c
+        expectType<typeof valueRequired>('c');
+        // @ts-expect-error `valueRequired` can not be undefined
+        expectType<typeof valueRequired>(undefined);
+
+        expectType<typeof valueNonRequired>('a');
+        // @ts-expect-error `value` can not be c
+        expectType<typeof valueNonRequired>('c');
+        expectType<typeof valueNonRequired>(undefined);
       });
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,13 @@ function array<Item, Options extends ArrayOptions>(
   } as unknown as GetType<Item[], Options>;
 }
 
+type LiteralOrNever<T> = string extends T ? never : T;
+
+function enumType<Enum extends string, Options extends GenericOptions>(
+  values: LiteralOrNever<Enum>[][],
+  options?: Options
+): GetType<typeof values[number], Options>;
+
 function enumType<Enum, Options extends GenericOptions>(
   values: Enum[],
   options?: Options
@@ -289,6 +296,7 @@ export default {
    *
    * - based on a TypeScript `enum` structure
    * - based on an array of `const`
+   * - based on an array of litteral strings
    *
    * Enum types may contain `null` as well.
    *
@@ -317,6 +325,10 @@ export default {
    *   requiredEnumAsConstArray: types.enum(SampleArray, { required: true }),
    *   // type: 'foo' | 'bar' | undefined
    *   optionalEnumAsConstArray: types.enum(SampleArray),
+   *   // type: 'foo' | 'bar'
+   *   requiredEnumAsStringLitteralArray: types.enum(['foo', 'bar'], { required: true }),
+   *   // type: 'foo' | 'bar' | undefined
+   *   optionalEnumAsStringLitteralArray: types.enum(['foo', 'bar']),
    * });
    */
   enum: enumType,


### PR DESCRIPTION
Hi,

Another PR about the enum types.
After a few tweaks, I managed to accept array of litteral strings as values of `enum`.

Now we have 

```ts
types.enum(['foo', 'bar'], { required: true })
```

that leads to the type 

```ts
'foo' | 'bar'
```

But we will accepts only litteral.

```ts
const arrayOfStrings = ['a', 'b'];
types.enum(arrayOfStrings);
```

is invalid