### PR TITLE
fix: Improve defaults type at schema declaration

### DIFF
--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -48,9 +48,11 @@ describe('model', () => {
   );
 
   type SimpleDocument = typeof simpleSchema[0];
+  type SimpleDefaults = typeof simpleSchema[1];
   type TimestampsDocument = typeof timestampsSchema[0];
-  let simpleModel: Model<SimpleDocument, typeof DEFAULTS>;
-  let timestampsModel: Model<TimestampsDocument, typeof DEFAULTS>;
+  type TimestampsDefaults = typeof timestampsSchema[1];
+  let simpleModel: Model<SimpleDocument, SimpleDefaults>;
+  let timestampsModel: Model<TimestampsDocument, TimestampsDefaults>;
 
   let doc: SimpleDocument;
   let docs: SimpleDocument[];

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -45,10 +45,7 @@ describe('schema', () => {
           foo?: boolean;
           bar: number;
         },
-        {
-          foo?: boolean;
-          bar?: number;
-        }
+        {}
       ]
     >(value);
     expectType<ObjectId>(value[0]?._id);
@@ -106,8 +103,7 @@ describe('schema', () => {
           bar: number;
         },
         {
-          foo?: boolean;
-          bar?: number;
+          foo: boolean;
         }
       ]
     >(value);
@@ -167,11 +163,7 @@ describe('schema', () => {
           createdAt: Date;
           updatedAt: Date;
         },
-        {
-          foo?: boolean;
-          createdAt?: Date;
-          updatedAt?: Date;
-        }
+        {}
       ]
     >(value);
     expectType<ObjectId>(value[0]?._id);
@@ -217,9 +209,7 @@ describe('schema', () => {
           _id: string;
           foo: number;
         },
-        {
-          foo?: number;
-        }
+        {}
       ]
     >(value);
     expectType<string>(value[0]?._id);
@@ -264,9 +254,7 @@ describe('schema', () => {
           _id: number;
           foo: string;
         },
-        {
-          foo?: string;
-        }
+        {}
       ]
     >(value);
     expectType<number>(value[0]?._id);
@@ -529,6 +517,9 @@ describe('schema', () => {
       updatedAt: Date;
     }>(value[0]);
     /* eslint-enable */
+    expectType<{
+      stringOptional: string;
+    }>(value[1]);
     expectType<ObjectId>(value[0]?._id);
   });
 });

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2,18 +2,18 @@ import { WithId } from 'mongodb';
 import types, { ObjectType } from './types';
 import { TimestampSchema, VALIDATION_ACTIONS, VALIDATION_LEVEL } from './utils';
 
-interface SchemaOptions<TProperties, TDefaults extends Partial<TProperties>> {
-  defaults?: TDefaults;
+interface SchemaOptions<TProperties> {
+  defaults?: Partial<TProperties>;
   timestamps?: boolean;
   validationAction?: VALIDATION_ACTIONS;
   validationLevel?: VALIDATION_LEVEL;
 }
 
-type TimestampsOptions = Required<Pick<SchemaOptions<unknown, any>, 'timestamps'>>;
+type TimestampsOptions = Required<Pick<SchemaOptions<unknown>, 'timestamps'>>;
 
 export type SchemaType<
   TProperties extends Record<string, unknown>,
-  TOptions extends SchemaOptions<unknown, any>
+  TOptions extends SchemaOptions<unknown>
 > = TOptions extends TimestampsOptions
   ? ObjectType<WithId<TProperties> & TimestampSchema>
   : ObjectType<WithId<TProperties>>;
@@ -92,8 +92,8 @@ function sanitize(value: any): void {
  */
 export default function schema<
   TProperties extends Record<string, unknown>,
-  TDefaults extends Partial<TProperties>,
-  TOptions extends SchemaOptions<TProperties, TDefaults>
+  TOptions extends SchemaOptions<TProperties>,
+  TDefaults extends TOptions['defaults'] = object
 >(properties: TProperties, options?: TOptions): [SchemaType<TProperties, TOptions>, TDefaults] {
   const {
     defaults,


### PR DESCRIPTION
When building a schema we're currently assigning `TDefaults` to `Partial<TProperties>` which is breaking the type safety for creating new documents provided by `DocumentForInsertWithoutDefaults`. This is because that type util (correctly) removes supplied default values for the model from the required properties when inserting a document, but because _all_ properties from `TProperties` are included in the type definition, it results in no keys remaining.

This wasn't caught in testing because rather than supplying our `Model<>` type with the default value returned when creating a schema, we're directly gathering the default type via `typeof DEFAULTS`. This commit also updates the tests to pull the type from the returned schema type signature.