### PR TITLE
fix: Allow explicit optional types on schemas

### DIFF
--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -522,4 +522,310 @@ describe('schema', () => {
     }>(value[1]);
     expectType<ObjectId>(value[0]?._id);
   });
+
+  test('explicit optional - simple', () => {
+    const value = schema({
+      bar: types.number({ required: true }),
+      foo: types.boolean({ required: false }),
+    });
+
+    expect(value).toEqual({
+      $validationAction: 'error',
+      $validationLevel: 'strict',
+      additionalProperties: false,
+      properties: {
+        __v: {
+          type: 'number',
+        },
+        _id: {
+          bsonType: 'objectId',
+        },
+        bar: {
+          type: 'number',
+        },
+        foo: {
+          type: 'boolean',
+        },
+      },
+      required: ['_id', 'bar'],
+      type: 'object',
+    });
+
+    expectType<
+      [
+        {
+          _id: ObjectId;
+          foo?: boolean;
+          bar: number;
+        },
+        {}
+      ]
+    >(value);
+    expectType<ObjectId>(value[0]?._id);
+    expectType<boolean | undefined>(value[0]?.foo);
+    expectType<typeof value[0]>({
+      _id: new ObjectId(),
+      bar: 123,
+      foo: true,
+    });
+    expectType<typeof value[0]>({
+      _id: new ObjectId(),
+      bar: 123,
+    });
+  });
+
+  test('explicit optional - full', () => {
+    const value = schema(
+      {
+        anyOptional: types.any({ required: false }),
+        anyRequired: types.any({ required: true }),
+        arrayOfObjects: types.array(
+          types.object(
+            {
+              foo: types.number(),
+            },
+            { required: true }
+          )
+        ),
+        arrayOptional: types.array(types.number({ required: false })),
+        arrayRequired: types.array(types.number(), { required: true }),
+        binaryOptional: types.binary({ required: false }),
+        binaryRequired: types.binary({ required: true }),
+        booleanOptional: types.boolean({ required: false }),
+        booleanRequired: types.boolean({ required: true }),
+        dateOptional: types.date({ required: false }),
+        dateRequired: types.date({ required: true }),
+        enumOptional: types.enum([...Object.values(TEST_ENUM), null]),
+        enumRequired: types.enum(Object.values(TEST_ENUM), { required: true }),
+        numberOptional: types.number({ required: false }),
+        numberRequired: types.number({ required: true }),
+        objectGenericOptional: types.objectGeneric(types.number({ required: false })),
+        objectGenericRequired: types.objectGeneric(types.number(), 'abc.+', { required: true }),
+        objectIdOptional: types.objectId({ required: false }),
+        objectIdRequired: types.objectId({ required: true }),
+        objectOptional: types.object({
+          foo: types.number({ required: false }),
+        }),
+        objectRequired: types.object(
+          {
+            foo: types.number({ required: false }),
+          },
+          { required: true }
+        ),
+        stringOptional: types.string({ required: false }),
+        stringRequired: types.string({ required: true }),
+      },
+      {
+        defaults: { stringOptional: 'foo' },
+        timestamps: true,
+        validationAction: VALIDATION_ACTIONS.WARN,
+        validationLevel: VALIDATION_LEVEL.MODERATE,
+      }
+    );
+
+    expect(value).toEqual({
+      $defaults: { stringOptional: 'foo' },
+      $validationAction: 'warn',
+      $validationLevel: 'moderate',
+      additionalProperties: false,
+      properties: {
+        __v: {
+          type: 'number',
+        },
+        _id: {
+          bsonType: 'objectId',
+        },
+        anyOptional: {
+          bsonType: [
+            'array',
+            'binData',
+            'bool',
+            'date',
+            'null',
+            'number',
+            'object',
+            'objectId',
+            'string',
+          ],
+        },
+        anyRequired: {
+          bsonType: [
+            'array',
+            'binData',
+            'bool',
+            'date',
+            'null',
+            'number',
+            'object',
+            'objectId',
+            'string',
+          ],
+        },
+        arrayOfObjects: {
+          items: {
+            additionalProperties: false,
+            properties: {
+              foo: {
+                type: 'number',
+              },
+            },
+            type: 'object',
+          },
+          type: 'array',
+        },
+        arrayOptional: {
+          items: {
+            type: 'number',
+          },
+          type: 'array',
+        },
+        arrayRequired: {
+          items: {
+            type: 'number',
+          },
+          type: 'array',
+        },
+        binaryOptional: {
+          bsonType: 'binData',
+        },
+        binaryRequired: {
+          bsonType: 'binData',
+        },
+        booleanOptional: {
+          type: 'boolean',
+        },
+        booleanRequired: {
+          type: 'boolean',
+        },
+        createdAt: {
+          bsonType: 'date',
+        },
+        dateOptional: {
+          bsonType: 'date',
+        },
+        dateRequired: {
+          bsonType: 'date',
+        },
+        enumOptional: {
+          enum: ['foo', 'bar', null],
+        },
+        enumRequired: {
+          enum: ['foo', 'bar'],
+        },
+        numberOptional: {
+          type: 'number',
+        },
+        numberRequired: {
+          type: 'number',
+        },
+        objectGenericOptional: {
+          additionalProperties: false,
+          patternProperties: {
+            '.+': {
+              type: 'number',
+            },
+          },
+          type: 'object',
+        },
+        objectGenericRequired: {
+          additionalProperties: false,
+          patternProperties: {
+            'abc.+': {
+              type: 'number',
+            },
+          },
+          type: 'object',
+        },
+
+        objectIdOptional: {
+          bsonType: 'objectId',
+        },
+        objectIdRequired: {
+          bsonType: 'objectId',
+        },
+        objectOptional: {
+          additionalProperties: false,
+          properties: {
+            foo: {
+              type: 'number',
+            },
+          },
+          type: 'object',
+        },
+        objectRequired: {
+          additionalProperties: false,
+          properties: {
+            foo: {
+              type: 'number',
+            },
+          },
+          type: 'object',
+        },
+        stringOptional: {
+          type: 'string',
+        },
+        stringRequired: {
+          type: 'string',
+        },
+        updatedAt: {
+          bsonType: 'date',
+        },
+      },
+      required: [
+        '_id',
+        'anyRequired',
+        'arrayRequired',
+        'binaryRequired',
+        'booleanRequired',
+        'dateRequired',
+        'enumRequired',
+        'numberRequired',
+        'objectGenericRequired',
+        'objectIdRequired',
+        'objectRequired',
+        'stringRequired',
+        'createdAt',
+        'updatedAt',
+      ],
+      type: 'object',
+    });
+
+    /* eslint-disable */
+    expectType<{
+      _id: ObjectId;
+      anyOptional?: any;
+      // This `any` can not be required in TS
+      anyRequired?: any;
+      arrayOptional?: (number | undefined)[];
+      arrayRequired: (number | undefined)[];
+      arrayOfObjects?: {
+        foo?: number;
+      }[];
+      binaryOptional?: Binary;
+      binaryRequired: Binary;
+      booleanOptional?: boolean;
+      booleanRequired: boolean;
+      dateOptional?: Date;
+      dateRequired: Date;
+      enumOptional?: TEST_ENUM | null;
+      enumRequired: TEST_ENUM;
+      numberOptional?: number;
+      numberRequired: number;
+      objectGenericOptional?: { [key: string]: number | undefined };
+      objectGenericRequired: { [key: string]: number | undefined };
+      objectIdOptional?: ObjectId;
+      objectIdRequired: ObjectId;
+      objectOptional?: { foo?: number };
+      objectRequired: { foo?: number };
+      stringOptional?: string;
+      stringRequired: string;
+      createdAt: Date;
+      updatedAt: Date;
+    }>(value[0]);
+    /* eslint-enable */
+    expectType<{
+      stringOptional: string;
+    }>(value[1]);
+    expectType<ObjectId>(value[0]?._id);
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,11 @@ type BSONType =
   | 'objectId'
   | 'string';
 
-type GetType<Type, Options> = Options extends RequiredOptions ? Type : Type | undefined;
+type GetType<Type, Options> = Options extends RequiredOptions
+  ? Options['required'] extends true
+    ? Type
+    : Type | undefined
+  : Type | undefined;
 
 type RequiredProperties<Properties> = {
   [Prop in keyof Properties]: undefined extends Properties[Prop] ? never : Prop;
@@ -133,7 +137,7 @@ function enumType<Enum, Options extends GenericOptions>(
   options?: Options
 ): GetType<Enum, Options> {
   return {
-    ...(options && 'required' in options ? { $required: true } : {}),
+    ...(options?.required ? { $required: true } : {}),
     enum: values,
   } as unknown as GetType<Enum, Options>;
 }
@@ -191,7 +195,7 @@ export function objectGeneric<Property, Options extends ObjectOptions>(
 function createSimpleType<Type>(type: BSONType) {
   return <Options extends GenericOptions>(options?: Options) => {
     return {
-      ...(options && 'required' in options ? { $required: true } : {}),
+      ...(options?.required ? { $required: true } : {}),
       ...(type === 'date' || type === 'objectId' || type === 'binData'
         ? { bsonType: type }
         : { type }),


### PR DESCRIPTION
Hello!

This PR allows to declare explicit optional types for schemas.

Currently if we try to do something like this:
```ts
const value = schema({
  age: types.number({ required: false }),
});
// age: number
```
`age` will be still required even if  `required` is set as `false`. 

With this changes, schema returns the correct type when `{required: false}` is passed in the options object
```ts
const value = schema({
  age: types.number({ required: false }),
});
// age: number | undefined
```

Let me know how it looks and if something needs to be modified ✌
