### PR TITLE
feat: Better `bulkWrite` types for insert operations

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -54,10 +54,10 @@ Calls the MongoDB [`bulkWrite()`](https://mongodb.github.io/node-mongodb-native/
 
 **Parameters:**
 
-| Name         | Type                                    | Attribute |
-| ------------ | --------------------------------------- | --------- |
-| `operations` | `Array<AnyBulkWriteOperation<TSchema>>` | required  |
-| `options`    | `BulkWriteOptions`                      | optional  |
+| Name         | Type                                            | Attribute |
+| ------------ | ----------------------------------------------- | --------- |
+| `operations` | `Array<BulkWriteOperation<TSchema, TDefaults>>` | required  |
+| `options`    | `BulkWriteOptions`                              | optional  |
 
 **Returns:**
 

--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -1,9 +1,10 @@
-import { AnyBulkWriteOperation, Collection, MongoError, ObjectId } from 'mongodb';
+import { Collection, MongoError, ObjectId } from 'mongodb';
 import { expectType } from 'ts-expect';
 import { Hooks } from '../hooks';
 import { abstract, build, Model } from '../model';
 import schema from '../schema';
 import Types from '../types';
+import { BulkWriteOperation } from '../utils';
 
 describe('model', () => {
   let collection: Collection;
@@ -153,7 +154,7 @@ describe('model', () => {
 
   describe('bulkWrite', () => {
     test('simple schema', async () => {
-      const operations: AnyBulkWriteOperation<SimpleDocument>[] = [
+      const operations: BulkWriteOperation<SimpleDocument, SimpleDefaults>[] = [
         {
           insertOne: {
             document: {
@@ -207,7 +208,7 @@ describe('model', () => {
     });
 
     test('schema with defaults', async () => {
-      const operations: AnyBulkWriteOperation<SimpleDocument>[] = [
+      const operations: BulkWriteOperation<SimpleDocument, SimpleDefaults>[] = [
         {
           insertOne: {
             document: {
@@ -218,7 +219,6 @@ describe('model', () => {
         },
         {
           insertOne: {
-            // @ts-expect-error TODO Fix operation types with defaults
             document: {
               foo: 'foo',
             },
@@ -376,7 +376,6 @@ describe('model', () => {
       await timestampsModel.bulkWrite([
         {
           insertOne: {
-            // @ts-expect-error TODO Fix operation types with timestamps
             document: {
               bar: 123,
               foo: 'foo',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,16 @@
-import { Join, NestedPaths, ObjectId, WithId } from 'mongodb';
-import type { AnyBulkWriteOperation, OptionalId, UpdateFilter } from 'mongodb';
+import { ObjectId } from 'mongodb';
+import type {
+  DeleteManyModel,
+  DeleteOneModel,
+  Join,
+  NestedPaths,
+  OptionalId,
+  ReplaceOneModel,
+  UpdateFilter,
+  UpdateManyModel,
+  UpdateOneModel,
+  WithId,
+} from 'mongodb';
 import { DeepPick } from './DeepPick';
 import { Hooks } from './hooks';
 
@@ -41,6 +52,28 @@ export type DocumentForInsert<TSchema, TDefaults extends Partial<TSchema>> = Ext
   ? Omit<DocumentForInsertWithoutDefaults<TSchema, TDefaults>, 'createdAt' | 'updatedAt'> &
       Partial<TimestampSchema>
   : DocumentForInsertWithoutDefaults<TSchema, TDefaults>;
+
+export type BulkWriteOperation<TSchema, TDefaults extends Partial<TSchema>> =
+  | {
+      insertOne: {
+        document: DocumentForInsert<TSchema, TDefaults>;
+      };
+    }
+  | {
+      replaceOne: ReplaceOneModel<TSchema>;
+    }
+  | {
+      updateOne: UpdateOneModel<TSchema>;
+    }
+  | {
+      updateMany: UpdateManyModel<TSchema>;
+    }
+  | {
+      deleteOne: DeleteOneModel<TSchema>;
+    }
+  | {
+      deleteMany: DeleteManyModel<TSchema>;
+    };
 
 export type ProjectionType<
   TSchema extends BaseSchema,
@@ -115,9 +148,9 @@ export function timestampUpdateFilter<TSchema>(
 }
 
 // Creates new operation objects so the original operations don't get mutated
-export function timestampBulkWriteOperation<TSchema>(
-  operation: AnyBulkWriteOperation<TSchema>
-): AnyBulkWriteOperation<TSchema> {
+export function timestampBulkWriteOperation<TSchema, TDefaults>(
+  operation: BulkWriteOperation<TSchema, TDefaults>
+): BulkWriteOperation<TSchema, TDefaults> {
   if ('insertOne' in operation) {
     return {
       insertOne: {


### PR DESCRIPTION
This adds our own version of the bulk write type, which takes into account the defaults for the `insertOne` operation.