### PR TITLE
feat: Properties with defaults as non-nullable types in schema

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -324,10 +324,10 @@ Calls the MongoDB [`insertMany()`](https://mongodb.github.io/node-mongodb-native
 
 **Parameters:**
 
-| Name        | Type               | Attribute |
-| ----------- | ------------------ | --------- |
-| `documents` | `Array<TSchema>`   | required  |
-| `options`   | `BulkWriteOptions` | optional  |
+| Name        | Type                                           | Attribute |
+| ----------- | ---------------------------------------------- | --------- |
+| `documents` | `Array<DocumentForInsert<TSchema, TDefaults>>` | required  |
+| `options`   | `BulkWriteOptions`                             | optional  |
 
 **Returns:**
 
@@ -348,10 +348,10 @@ Calls the MongoDB [`insertOne()`](https://mongodb.github.io/node-mongodb-native/
 
 **Parameters:**
 
-| Name       | Type               | Attribute |
-| ---------- | ------------------ | --------- |
-| `document` | `TSchema`          | required  |
-| `options`  | `InsertOneOptions` | optional  |
+| Name       | Type                                    | Attribute |
+| ---------- | --------------------------------------- | --------- |
+| `document` | `DocumentForInsert<TSchema, TDefaults>` | required  |
+| `options`  | `InsertOneOptions`                      | optional  |
 
 **Returns:**
 

--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -14,7 +14,11 @@ in the MongoDB docs.
 Under the hood it is just a wrapper around the [`object`](api/types.md#object) type with some default properties
 (e.g. `_id` and timestamps properties).
 
-While the default `_id` property is added with an `ObjectId` type, its type can be customized into a `string` or a `number`
+While the default `_id` property is added with an `ObjectId` type, its type can be customized into a `string` or a `number`.
+
+The defaults defined in the `options` are exported as a result type (the second value in the return tuple) and
+are used when computing the schema properties nullable status.
+Properties which are not required, but have a default value defined, will be non-nullable in the final schema type.
 
 **Parameters:**
 
@@ -43,7 +47,8 @@ const userSchema = schema({
   lastName: types.string({ required: true }),
 });
 
-type UserDocument = typeof userSchema[0];
+export type UserDocument = typeof userSchema[0];
+export type UserDefaults = typeof userSchema[1];
 
 const orderSchema = schema(
   {
@@ -59,5 +64,6 @@ const orderSchema = schema(
   }
 );
 
-type OrderDocument = typeof orderSchema[0];
+export type OrderDocument = typeof orderSchema[0];
+export type OrderDefaults = typeof orderSchema[1];
 ```

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -2,6 +2,25 @@
 
 # Utilities
 
+## `DocumentForInsert`
+
+This TypeScript type is useful to define an document representation for an insertion operation, where the `_id` and
+other properties which have defaults defined are not required.
+
+```ts
+import { DocumentForInsert } from 'papr';
+
+import type { OrderDocument, OrderDefaults } from './schema';
+
+const newOrder: DocumentForInsert<OrderDocument, OrderDefaults> = {
+  user: 'John',
+};
+
+newOrder._id; // ObjectId | undefined
+newOrder.user; // string
+newOrder.product; // string | undefined
+```
+
 ## `ProjectionType`
 
 This TypeScript type is useful to compute the sub-document resulting from a `find*` operation which used a projection.

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -99,7 +99,7 @@ describe('schema', () => {
       [
         {
           _id: ObjectId;
-          foo?: boolean;
+          foo: boolean;
           bar: number;
         },
         {
@@ -114,6 +114,7 @@ describe('schema', () => {
       bar: 123,
       foo: true,
     });
+    // @ts-expect-error Error because `foo` is missing
     expectType<typeof value[0]>({
       _id: new ObjectId(),
       bar: 123,
@@ -306,11 +307,13 @@ describe('schema', () => {
           },
           { required: true }
         ),
-        stringOptional: types.string(),
+        stringOptionalWithDefault: types.string(),
         stringRequired: types.string({ required: true }),
       },
       {
-        defaults: { stringOptional: 'foo' },
+        defaults: {
+          stringOptionalWithDefault: 'foo',
+        },
         timestamps: true,
         validationAction: VALIDATION_ACTIONS.WARN,
         validationLevel: VALIDATION_LEVEL.MODERATE,
@@ -318,7 +321,9 @@ describe('schema', () => {
     );
 
     expect(value).toEqual({
-      $defaults: { stringOptional: 'foo' },
+      $defaults: {
+        stringOptionalWithDefault: 'foo',
+      },
       $validationAction: 'warn',
       $validationLevel: 'moderate',
       additionalProperties: false,
@@ -455,7 +460,7 @@ describe('schema', () => {
           },
           type: 'object',
         },
-        stringOptional: {
+        stringOptionalWithDefault: {
           type: 'string',
         },
         stringRequired: {
@@ -511,14 +516,14 @@ describe('schema', () => {
       objectIdRequired: ObjectId;
       objectOptional?: { foo?: number };
       objectRequired: { foo?: number };
-      stringOptional?: string;
+      stringOptionalWithDefault: string;
       stringRequired: string;
       createdAt: Date;
       updatedAt: Date;
     }>(value[0]);
     /* eslint-enable */
     expectType<{
-      stringOptional: string;
+      stringOptionalWithDefault: string;
     }>(value[1]);
     expectType<ObjectId>(value[0]?._id);
   });

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,7 +1,6 @@
-import { MongoError, ObjectId } from 'mongodb';
+import { AnyBulkWriteOperation, MongoError, ObjectId } from 'mongodb';
 import type {
   AggregateOptions,
-  AnyBulkWriteOperation,
   BulkWriteOptions,
   BulkWriteResult,
   Collection,
@@ -706,7 +705,7 @@ export function build<TSchema extends BaseSchema, TDefaults extends Partial<TSch
    * @description
    * Calls the MongoDB [`insertMany()`](https://mongodb.github.io/node-mongodb-native/4.1/classes/Collection.html#insertMany) method.
    *
-   * @param documents {Array<TSchema>}
+   * @param documents {Array<DocumentForInsert<TSchema, TDefaults>>}
    * @param [options] {BulkWriteOptions}
    *
    * @returns {Promise<Array<TSchema>>}
@@ -757,7 +756,7 @@ export function build<TSchema extends BaseSchema, TDefaults extends Partial<TSch
    * @description
    * Calls the MongoDB [`insertOne()`](https://mongodb.github.io/node-mongodb-native/4.1/classes/Collection.html#insertOne) method.
    *
-   * @param document {TSchema}
+   * @param document {DocumentForInsert<TSchema, TDefaults>}
    * @param [options] {InsertOneOptions}
    *
    * @returns {Promise<TSchema>}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,6 +90,25 @@ export function getIds(ids: (string | ObjectId)[] | Set<string>): ObjectId[] {
  * @module intro
  * @description
  *
+ * ## `DocumentForInsert`
+ *
+ * This TypeScript type is useful to define an document representation for an insertion operation, where the `_id` and
+ * other properties which have defaults defined are not required.
+ *
+ * ```ts
+ * import { DocumentForInsert } from 'papr';
+ *
+ * import type { OrderDocument, OrderDefaults } from './schema';
+ *
+ * const newOrder: DocumentForInsert<OrderDocument, OrderDefaults> = {
+ *   user: 'John',
+ * };
+ *
+ * newOrder._id; // ObjectId | undefined
+ * newOrder.user; // string
+ * newOrder.product; // string | undefined
+ * ```
+ *
  * ## `ProjectionType`
  *
  * This TypeScript type is useful to compute the sub-document resulting from a `find*` operation which used a projection.
@@ -128,6 +147,7 @@ export function getIds(ids: (string | ObjectId)[] | Set<string>): ObjectId[] {
  * }
  * ```
  */
+
 // Creates new update object so the original doesn't get mutated
 export function timestampUpdateFilter<TSchema>(
   update: UpdateFilter<TSchema>


### PR DESCRIPTION
Properties defined as optional in the schema, but which have defaults defined, are non-nullable in the final schema type.

Required changes: Optional properties with defaults defined no longer need a fallback value when reading them from documents.

Closes #209 