### PR TITLE
refactor: Remove custom model type support

### DIFF
--- a/docs/api/papr.md
+++ b/docs/api/papr.md
@@ -32,7 +32,7 @@ const paprWithOptions = new Papr({
 
 ## `initialize`
 
-Initialize existing and future registered models with a mongo db instance
+Initialize existing and future registered models with a mongo db instance.
 
 **Parameters:**
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  testPathIgnorePatterns: [
+    '<rootDir>/build/',
+    '<rootDir>/cjs/',
+    '<rootDir>/esm/',
+    '<rootDir>/node_modules/',
+    '<rootDir>/tmp/',
+  ]
+};

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -10,6 +10,7 @@ describe('index', () => {
   let collection: Collection;
 
   const COLLECTION = 'testcollection';
+  const COLLECTION_OTHER = 'testcollection2';
   const DEFAULTS = {
     foo: 'bar',
   };
@@ -181,12 +182,12 @@ describe('index', () => {
   test('updateSchemas', async () => {
     (db.collection as jest.Mock)
       .mockReturnValueOnce(collection)
-      .mockReturnValueOnce({ collectionName: 'testcollection2' });
+      .mockReturnValueOnce({ collectionName: COLLECTION_OTHER });
 
     const papr = new Papr();
 
     papr.model(COLLECTION, testSchema1);
-    papr.model('testcollection2', testSchema2);
+    papr.model(COLLECTION_OTHER, testSchema2);
     papr.initialize(db);
 
     await papr.updateSchemas();
@@ -213,7 +214,7 @@ describe('index', () => {
         },
       },
     });
-    expect(db.createCollection).toHaveBeenCalledWith('testcollection2', {
+    expect(db.createCollection).toHaveBeenCalledWith(COLLECTION_OTHER, {
       validationAction: 'warn',
       validationLevel: 'moderate',
       validator: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export default class Papr {
   }
 
   /**
-   * Initialize existing and future registered models with a mongo db instance
+   * Initialize existing and future registered models with a mongo db instance.
    *
    * @param db {mongodb.Db}
    *
@@ -77,16 +77,11 @@ export default class Papr {
    * @example
    * const User = papr.model('users', userSchema);
    */
-  model<
-    TSchema extends BaseSchema,
-    TDefaults extends Partial<TSchema>,
-    // We're using `ExternalModel` as a return type here, which extends a `Model<TSchema>` in order to allow
-    // custom static methods to be applied to the resulting model.
-    ExternalModel extends Model<TSchema, TDefaults> = Model<TSchema, TDefaults>
-  >(collectionName: string, collectionSchema: [TSchema, TDefaults]): ExternalModel {
-    // We're casting to `ExternalModel` here we need to return `ExternalModel` as a type,
-    // which is not guaranteed to be equal to `Model`.
-    const model = abstract(collectionSchema) as ExternalModel;
+  model<TSchema extends BaseSchema, TDefaults extends Partial<TSchema>>(
+    collectionName: string,
+    collectionSchema: [TSchema, TDefaults]
+  ): Model<TSchema, TDefaults> {
+    const model = abstract(collectionSchema) as Model<TSchema, TDefaults>;
 
     if (this.db) {
       build(collectionSchema, model, this.db.collection(collectionName), this.options);

--- a/src/model.ts
+++ b/src/model.ts
@@ -123,7 +123,9 @@ function abstractMethod(): void {
   throw new Error('Collection is not initialized!');
 }
 
-export function abstract<TSchema>(schema: TSchema): unknown {
+export function abstract<TSchema extends BaseSchema, TDefaults extends Partial<TSchema>>(
+  schema: [TSchema, TDefaults]
+): unknown {
   return {
     aggregate: abstractMethod,
     bulkWrite: abstractMethod,


### PR DESCRIPTION
Closes #212

This removes the undocumented `ExternalModel` type support in `model()`. Since it was undocumented and untested, there are little changes except the actual source code.