### PR TITLE
feat: Make array members non-optional by default

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -13,6 +13,10 @@ The following data types are available to define the schemas of your `papr` mode
 ## `array`
 
 Creates an array consisting of items of a single type.
+Note that the "required" option will not be respected on the type passed to
+`array`.
+All inner types are "required", i.e. non-optional, by default.
+e.g. types.array(types.number({ required: true })) is equivalent to types.array(types.number())
 
 **Parameters:**
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -13,10 +13,6 @@ The following data types are available to define the schemas of your `papr` mode
 ## `array`
 
 Creates an array consisting of items of a single type.
-Note that the "required" option will not be respected on the type passed to
-`array`.
-All inner types are "required", i.e. non-optional, by default.
-e.g. types.array(types.number({ required: true })) is equivalent to types.array(types.number())
 
 **Parameters:**
 
@@ -37,6 +33,9 @@ import { schema, types } from 'papr';
 schema({
   requiredList: types.array(types.number(), { required: true }),
   optionalList: types.array(types.number()),
+  // All inner types are `required` by default, so optionalList and anotherOptionalList
+  // are equivalent types
+  anotherOptionalList: types.array(types.number({ required: true }))
   listWithAllOptions: types.array(types.number(), {
     maxItems: 10,
     minItems: 1,

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -274,12 +274,9 @@ describe('schema', () => {
         anyOptional: types.any(),
         anyRequired: types.any({ required: true }),
         arrayOfObjects: types.array(
-          types.object(
-            {
-              foo: types.number(),
-            },
-            { required: true }
-          )
+          types.object({
+            foo: types.number(),
+          })
         ),
         arrayOptional: types.array(types.number()),
         arrayRequired: types.array(types.number(), { required: true }),
@@ -490,8 +487,8 @@ describe('schema', () => {
       anyOptional?: any;
       // This `any` can not be required in TS
       anyRequired?: any;
-      arrayOptional?: (number | undefined)[];
-      arrayRequired: (number | undefined)[];
+      arrayOptional?: number[];
+      arrayRequired: number[];
       arrayOfObjects?: {
         foo?: number;
       }[];
@@ -580,14 +577,11 @@ describe('schema', () => {
         anyOptional: types.any({ required: false }),
         anyRequired: types.any({ required: true }),
         arrayOfObjects: types.array(
-          types.object(
-            {
-              foo: types.number(),
-            },
-            { required: true }
-          )
+          types.object({
+            foo: types.number(),
+          })
         ),
-        arrayOptional: types.array(types.number({ required: false })),
+        arrayOptional: types.array(types.number()),
         arrayRequired: types.array(types.number(), { required: true }),
         binaryOptional: types.binary({ required: false }),
         binaryRequired: types.binary({ required: true }),
@@ -796,8 +790,8 @@ describe('schema', () => {
       anyOptional?: any;
       // This `any` can not be required in TS
       anyRequired?: any;
-      arrayOptional?: (number | undefined)[];
-      arrayRequired: (number | undefined)[];
+      arrayOptional?: number[];
+      arrayRequired: number[];
       arrayOfObjects?: {
         foo?: number;
       }[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,7 +121,7 @@ export function any<Options extends GenericOptions>(options?: Options): any {
 function array<Item, Options extends ArrayOptions>(
   items: Item,
   options?: Options
-): GetType<Item[], Options> {
+): GetType<NonNullable<Item>[], Options> {
   const { required, ...otherOptions } = options || {};
 
   return {
@@ -129,7 +129,7 @@ function array<Item, Options extends ArrayOptions>(
     items,
     type: 'array',
     ...otherOptions,
-  } as unknown as GetType<Item[], Options>;
+  } as unknown as GetType<NonNullable<Item>[], Options>;
 }
 
 function enumType<Enum, Options extends GenericOptions>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,10 @@ function string<Options extends StringOptions>(options?: Options): GetType<strin
 export default {
   /**
    * Creates an array consisting of items of a single type.
+   * Note that the "required" option will not be respected on the type passed to
+   * `array`.
+   * All inner types are "required", i.e. non-optional, by default.
+   * e.g. types.array(types.number({ required: true })) is equivalent to types.array(types.number())
    *
    * @param item {TItem}
    * @param [options] {ArrayOptions}
@@ -237,6 +241,7 @@ export default {
    *     uniqueItems: true,
    *   }),
    * });
+   *
    */
   array,
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,10 +216,6 @@ function string<Options extends StringOptions>(options?: Options): GetType<strin
 export default {
   /**
    * Creates an array consisting of items of a single type.
-   * Note that the "required" option will not be respected on the type passed to
-   * `array`.
-   * All inner types are "required", i.e. non-optional, by default.
-   * e.g. types.array(types.number({ required: true })) is equivalent to types.array(types.number())
    *
    * @param item {TItem}
    * @param [options] {ArrayOptions}
@@ -234,6 +230,9 @@ export default {
    * schema({
    *   requiredList: types.array(types.number(), { required: true }),
    *   optionalList: types.array(types.number()),
+   *   // All inner types are `required` by default, so optionalList and anotherOptionalList
+   *   // are equivalent types
+   *   anotherOptionalList: types.array(types.number({ required: true }))
    *   listWithAllOptions: types.array(types.number(), {
    *     maxItems: 10,
    *     minItems: 1,


### PR DESCRIPTION
closes #227

## Background

The more I looked into this, the more I became convinced that:

1. Array elements should be non-optional by default, full stop.
2. The reason they are not is a side-effect of the way types are built by papr, not an expected outcome of the papr design

For point 1. --  an array member being "required" or not has _zero_ impact on the generated JSON Schema. And a collection with a JSON schema validator will not validate a document that has `null` or `undefined` array members. (Try it yourself!)

For point 2. --   `types` methods do double duty in `papr`: they output the generated JSON schema for the schema and, through type-casting, generate typescript types to use in code. 

Before this change, the `array` method's return value was `GetType<Item[], Options>` In order to generate the appropriate JSON schema for array properties, we must pass a `types` method to the `array` method (e.g. `types.array(types.number())`). Thus, the generic `Item` type for the `array` method will be a papr type, and thus  subject to the `required` (in schema) = optional (in TS) expectation. However, a `required` type passed to an array does not generate any additional JSON Schema, because `required` only does so for object properties. So in this case, `required` simply functions to say whether `Item` is, for example, `number` or `number | undefined`. 

I consider this an unexpected side-effect, because though it makes sense given that we are using a generic `Item` type, it is not actually useful behavior for consumers of the library. 

## Solution

Given that we do not want `Item` to ever be `undefined`, we can use the extant Typescript [`NonNullable` utility type](https://www.typescriptlang.org/docs/handbook/utility-types.html#nonnullabletype) to make sure that array members are always required.

Admittedly, this means that `required`, when passed to a type that is then passed to `array`, no longer does anything (for TS, it already did nothing for the JSON schema), but I think this is probably an acceptable quirk of the API. Ideally, `required` would not be possible to pass to the type that is the first argument to `array`, but I didn't see a straightforward way to make that happen without a much larger change.