### PR TITLE
fix: Update sed command for macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,10 @@ set -euxo pipefail
 
 tsc --project ./tsconfig-esm.json
 
-sed -i '' -e "s/from '.\/\(.*\)';/from '.\/\1.js';/g" ./esm/*.js
+# https://stackoverflow.com/a/22084103
+# This works in Linux and MacOS
+sed --in-place=.backup --expression="s/from '.\/\(.*\)';/from '.\/\1.js';/g" ./esm/*.js
+rm ./esm/*.js.backup
 
 # CommonJS
 

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ tsc --project ./tsconfig-esm.json
 
 # https://stackoverflow.com/a/22084103
 # This works in Linux and MacOS
-sed --in-place=.backup --expression="s/from '.\/\(.*\)';/from '.\/\1.js';/g" ./esm/*.js
+sed -i.backup -e "s/from '.\/\(.*\)';/from '.\/\1.js';/g" ./esm/*.js
 rm ./esm/*.js.backup
 
 # CommonJS

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 
 tsc --project ./tsconfig-esm.json
 
-sed -i "s/from '.\/\(.*\)';/from '.\/\1.js';/g" ./esm/*.js
+sed -i '' -e "s/from '.\/\(.*\)';/from '.\/\1.js';/g" ./esm/*.js
 
 # CommonJS
 


### PR DESCRIPTION
Noticed this locally, and @duncanbeevers [flagged this](https://github.com/plexinc/papr/pull/195#issuecomment-1129994806) as well. The `sed` command does not work on macOS as written.

Stack Overflow gave me the fix here: https://stackoverflow.com/questions/19456518/error-when-using-sed-with-find-command-on-os-x-invalid-command-code

Hopefully this works on linux as well 😬 