### PR TITLE
chore: Remove incorrect config from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "commitMessageAction": "Upgrade",
   "commitMessagePrefix": "chore:",
   "commitMessageTopic": "{{depName}}",
-  "extends": ["config:base", ":disableHost(registry.npmjs.org)"],
+  "extends": ["config:base"],
   "labels": ["dependencies"],
   "packageRules": [
     {


### PR DESCRIPTION
Per https://github.com/renovatebot/renovate/issues/11547#issuecomment-1168714087 we shouldn't be setting this (and I'm 99% certain we copied this from an internal repo anyway, given our private repository credentials aren't in this repo).