### PR TITLE
fix: Use Record for objectGeneric type

### DIFF
--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -528,12 +528,13 @@ describe('types', () => {
           })
         );
         expectType<
-          | {
-              [key: string]: {
+          | Record<
+              string,
+              {
                 foo?: boolean;
                 bar: number;
-              };
-            }
+              }
+            >
           | undefined
         >(value);
         const item = value?.item;
@@ -589,12 +590,7 @@ describe('types', () => {
             type: 'object',
           })
         );
-        expectType<
-          | {
-              [key: string]: boolean | undefined;
-            }
-          | undefined
-        >(value);
+        expectType<Record<string, boolean | undefined> | undefined>(value);
       });
     });
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { ObjectId, Binary } from 'mongodb';
+import { Binary, ObjectId } from 'mongodb';
 import { Flatten } from './utils';
 
 // These options are based on the available keywords from:
@@ -56,11 +56,14 @@ type GetType<Type, Options> = Options extends RequiredOptions
     : Type | undefined
   : Type | undefined;
 
-type RequiredProperties<Properties> = {
+export type RequiredProperties<Properties> = {
   [Prop in keyof Properties]: undefined extends Properties[Prop] ? never : Prop;
 }[keyof Properties];
 
-type OptionalProperties<Properties> = Exclude<keyof Properties, RequiredProperties<Properties>>;
+export type OptionalProperties<Properties> = Exclude<
+  keyof Properties,
+  RequiredProperties<Properties>
+>;
 
 // We define properties which extend `undefined` as true optional properties `[Prop]?: Value`
 export type ObjectType<Properties> = Flatten<
@@ -178,7 +181,7 @@ export function objectGeneric<Property, Options extends ObjectOptions>(
   property: Property,
   pattern = '.+',
   options?: Options
-): GetType<ObjectType<{ [key: string]: Property }>, Options> {
+): GetType<Record<string, Property>, Options> {
   const { required, ...otherOptions } = options || {};
 
   return {
@@ -189,7 +192,7 @@ export function objectGeneric<Property, Options extends ObjectOptions>(
     },
     type: 'object',
     ...otherOptions,
-  } as unknown as GetType<ObjectType<{ [key: string]: Property }>, Options>;
+  } as unknown as GetType<Record<string, Property>, Options>;
 }
 
 function createSimpleType<Type>(type: BSONType) {


### PR DESCRIPTION
The type we were using before for `objectGeneric` seems to present some issues when combined with the new nested properties support in `UpdateFilter` in `mongodb` v4.8.

There's no reason to be using `ObjectType` there with a plain object, when we can just express that type using `Record`.