### PR TITLE
feat: `oneOf` type

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -300,6 +300,29 @@ schema({
 });
 ```
 
+## `oneOf`
+
+Creates a union type of multiple other types.
+
+This is useful when combined with `objectGeneric`.
+
+**Parameters:**
+
+| Name       | Type          | Attribute |
+| ---------- | ------------- | --------- |
+| `...types` | `Array<Type>` | required  |
+
+**Example:**
+
+```ts
+import { schema, types } from 'papr';
+
+schema({
+  optionalStringOrNumber: types.oneOf([types.string(), types.number()]),
+  requiredStringOrNumber: types.oneOf([types.string(), types.number()], { required: true }),
+});
+```
+
 ## `string`
 
 Creates a string type.

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -650,4 +650,57 @@ describe('types', () => {
       });
     });
   });
+
+  describe('compound types', () => {
+    describe('oneOf', () => {
+      test('default', () => {
+        const value = types.oneOf([types.number(), types.string()]);
+
+        expect(value).toEqual(
+          expect.objectContaining({
+            oneOf: [
+              {
+                type: 'number',
+              },
+              {
+                type: 'string',
+              },
+            ],
+          })
+        );
+        expectType<number | string | undefined>(value);
+        // @ts-expect-error `value` should not be `boolean`
+        expectType<boolean>(value);
+        expectType<typeof value>(123);
+        expectType<typeof value>('foo');
+        expectType<typeof value>(undefined);
+      });
+    });
+
+    test('required', () => {
+      const value = types.oneOf([types.boolean(), types.string()], { required: true });
+
+      expect(value).toEqual(
+        expect.objectContaining({
+          oneOf: [
+            {
+              $required: true,
+              type: 'boolean',
+            },
+            {
+              $required: true,
+              type: 'string',
+            },
+          ],
+        })
+      );
+      expectType<boolean | string>(value);
+      // @ts-expect-error `value` should not be `number`
+      expectType<number>(value);
+      // @ts-expect-error `value` should not be `undefined`
+      expectType<undefined>(value);
+      expectType<typeof value>(true);
+      expectType<typeof value>('foo');
+    });
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,24 @@ export function objectGeneric<Property, Options extends ObjectOptions>(
   } as unknown as GetType<Record<string, Property>, Options>;
 }
 
+export function oneOf<Types extends any[], Options extends GenericOptions>(
+  types: Types,
+  options?: Options
+): GetType<NonNullable<Types[number]>, Options> {
+  const { required } = options || {};
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return {
+    oneOf: required
+      ? // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        types.map((type) => ({
+          ...type,
+          $required: true,
+        }))
+      : types,
+  } as unknown as GetType<NonNullable<Types[number]>, Options>;
+}
+
 function createSimpleType<Type>(type: BSONType) {
   return <Options extends GenericOptions>(options?: Options) => {
     return {
@@ -463,6 +481,23 @@ export default {
    * });
    */
   objectId: createSimpleType<ObjectId>('objectId'),
+
+  /**
+   * Creates a union type of multiple other types.
+   *
+   * This is useful when combined with `objectGeneric`.
+   *
+   * @param ...types {Type[]}
+   *
+   * @example
+   * import { schema, types } from 'papr';
+   *
+   * schema({
+   *   optionalStringOrNumber: types.oneOf([types.string(), types.number()]),
+   *   requiredStringOrNumber: types.oneOf([types.string(), types.number()], { required: true }),
+   * });
+   */
+  oneOf,
 
   /**
    * Creates a string type.


### PR DESCRIPTION
Creates a union type of multiple other types.

This is useful when combined with `objectGeneric`.