### PR TITLE
feat: `unknown` type

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -346,3 +346,19 @@ schema({
   unknownData: types.any(),
 });
 ```
+
+## `unknown`
+
+This allows any value to be assigned, but is typed as unknown to force assertions
+before relying on the data. Like with `any`, we recommend avoiding this type.
+It only exists as an escape hatch for unknown data.
+
+**Example:**
+
+```ts
+import { schema, types } from 'papr';
+
+schema({
+  unknownData: types.unknown(),
+});
+```

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -593,5 +593,61 @@ describe('types', () => {
         expectType<Record<string, boolean | undefined> | undefined>(value);
       });
     });
+
+    describe('unknown', () => {
+      test('default', () => {
+        const value = types.unknown();
+
+        expect(value).toEqual({
+          bsonType: [
+            'array',
+            'binData',
+            'bool',
+            'date',
+            'null',
+            'number',
+            'object',
+            'objectId',
+            'string',
+          ],
+        });
+
+        expectType<unknown>(value);
+        expectType<typeof value>(undefined);
+        expectType<typeof value>('foo');
+        expectType<typeof value>(123);
+      });
+
+      test('required', () => {
+        const value = types.unknown({ required: true });
+
+        expect(value).toEqual({
+          $required: true,
+          bsonType: [
+            'array',
+            'binData',
+            'bool',
+            'date',
+            'null',
+            'number',
+            'object',
+            'objectId',
+            'string',
+          ],
+        });
+
+        expectType<unknown>(value);
+        expectType<typeof value>(undefined);
+        expectType<typeof value>('foo');
+        expectType<typeof value>(123);
+      });
+
+      test('options', () => {
+        // @ts-expect-error invalid option
+        types.unknown({ maximum: 1 });
+        // @ts-expect-error invalid option
+        types.unknown({ maxLength: 1 });
+      });
+    });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,10 @@ function string<Options extends StringOptions>(options?: Options): GetType<strin
   } as unknown as GetType<string, Options>;
 }
 
+function unknown<Options extends GenericOptions>(options?: Options): unknown {
+  return any(options) as unknown;
+}
+
 export default {
   /**
    * Creates an array consisting of items of a single type.
@@ -499,4 +503,18 @@ export default {
    */
   // eslint-disable-next-line sort-keys
   any,
+
+  /**
+   * This allows any value to be assigned, but is typed as unknown to force assertions
+   * before relying on the data. Like with `any`, we recommend avoiding this type.
+   * It only exists as an escape hatch for unknown data.
+   *
+   * @example
+   * import { schema, types } from 'papr';
+   *
+   * schema({
+   *   unknownData: types.unknown(),
+   * });
+   */
+  unknown,
 };


### PR DESCRIPTION
This is an alternative to the `any` type - providing the same escape hatch but with data returned as `unknown` which forces consumers to use assertions before using the properties.