### PR TITLE
fix: Correct TimestampSchema ternary in DocumentForInsert

### DIFF
--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -1179,6 +1179,11 @@ describe('model', () => {
       await simpleModel.insertOne({});
     });
 
+    test('simple schema, including fields missing from schema', async () => {
+      // @ts-expect-error Ignore included fields missing from schema
+      await simpleModel.insertOne({ createdAt: new Date() });
+    });
+
     test('timestamps schema', async () => {
       const result = await timestampsModel.insertOne({
         bar: 123,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,10 +45,10 @@ export type DocumentForInsertWithoutDefaults<TSchema, TDefaults extends Partial<
 > &
   Partial<Pick<TSchema, keyof TDefaults & keyof TSchema>>;
 
-export type DocumentForInsert<TSchema, TDefaults extends Partial<TSchema>> = Extract<
-  keyof TSchema,
-  'createdAt'
-> extends 'createdAt'
+export type DocumentForInsert<
+  TSchema,
+  TDefaults extends Partial<TSchema>
+> = TSchema extends TimestampSchema
   ? Omit<DocumentForInsertWithoutDefaults<TSchema, TDefaults>, 'createdAt' | 'updatedAt'> &
       Partial<TimestampSchema>
   : DocumentForInsertWithoutDefaults<TSchema, TDefaults>;


### PR DESCRIPTION
In the `DocumentForInsert` type we are checking if `Extract<keyof TSchema, 'createdAt'> extends 'createdAt'`. When our `TSchema` does not have `'createdAt'` as a property, the expression `Extract<keyof TSchema, 'createdAt'>` produces `never`. This results in `never extends 'createdAt'` being the ternary we're using and somewhat confusingly [`never` will always extends `'createdAt'`](https://www.typescriptlang.org/play?#code/C4TwDgpgBA6gFgQ2AQQLYEkoF4oDsIBuEATlBAB7AS4AmAzlAOR2QDGAlgGbusBqCAGwCuERlAD8eIagBGJKAC4odYMXa4A5gFgAULtYB7XCqhUVS+EjSYcARgDcuoA) because `never` is the bottom type and technically in all other types.

This means the current check will always evaluate to true, and even for schemas without timestamps enabled we are allowing users to pass timestamp fields when inserting a document without showing a type error.

This replaces that ternary with a simple `TSchema extends TimestampSchema` ternary which accomplishes what we're looking. 