### PR TITLE
feat: `tuple` type

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -358,6 +358,31 @@ schema({
 });
 ```
 
+## `tuple`
+
+Creates a tuple type for the items in the supplied items array.
+
+Items passed to tuple must be readonly to preserve their order and any optional properties preceding a required property are implicitly required as well.
+
+**Parameters:**
+
+| Name               | Type             | Attribute |
+| ------------------ | ---------------- | --------- |
+| `types`            | `Array<Type>`    | required  |
+| `options`          | `GenericOptions` | optional  |
+| `options.required` | `boolean`        | optional  |
+
+**Example:**
+
+```ts
+import { schema, types } from 'papr';
+
+schema({
+  requiredTuple: types.tuple([types.number(), types.string()] as const, { required: true }),
+  optionalTuple: types.tuple([types.number(), types.string()] as const),
+});
+```
+
 ## `any`
 
 We recommend avoiding this type. It only exists as an escape hatch for unknown data.

--- a/src/TupleItems.ts
+++ b/src/TupleItems.ts
@@ -1,0 +1,23 @@
+type LastRequiredPosition<Items extends readonly unknown[]> = Items extends readonly [
+  ...infer Rest,
+  infer Last
+]
+  ? Last extends NonNullable<Last>
+    ? [...Rest, Last]['length']
+    : LastRequiredPosition<Rest>
+  : 0;
+
+type TupleSplit<
+  Items extends readonly unknown[],
+  Position extends number,
+  Result extends unknown[] = []
+> = Result['length'] extends Position
+  ? Result
+  : Items extends readonly [infer First, ...infer Rest]
+  ? TupleSplit<readonly [...Rest], Position, [...Result, NonNullable<First>]>
+  : Result;
+
+export type TupleItems<
+  Type extends readonly unknown[],
+  Range extends number = LastRequiredPosition<Type>
+> = { [Value in Range]: TupleSplit<Type, Value> }[Range];

--- a/src/__tests__/TupleItems.test.ts
+++ b/src/__tests__/TupleItems.test.ts
@@ -1,0 +1,37 @@
+import { expectType, TypeEqual } from 'ts-expect';
+
+import type { TupleItems } from '../TupleItems';
+
+// with required properties
+expectType<
+  TypeEqual<
+    TupleItems<readonly ['a', 'b', 'c' | undefined, 'd' | undefined]>,
+    ['a', 'b'] | ['a', 'b', 'c'] | ['a', 'b', 'c', 'd']
+  >
+>(true);
+
+// with required properties and preceding optional properties
+expectType<
+  TypeEqual<
+    TupleItems<readonly ['a' | undefined, 'b', 'c' | undefined, 'd' | undefined]>,
+    ['a', 'b'] | ['a', 'b', 'c'] | ['a', 'b', 'c', 'd']
+  >
+>(true);
+
+// with only optional properties
+expectType<
+  TypeEqual<
+    TupleItems<readonly ['a' | undefined, 'b' | undefined, 'c' | undefined]>,
+    [] | ['a'] | ['a', 'b'] | ['a', 'b', 'c']
+  >
+>(true);
+
+// with only required properties
+expectType<TypeEqual<TupleItems<readonly ['a', 'b', 'c']>, ['a', 'b', 'c']>>(true);
+
+// with no properties
+expectType<TypeEqual<TupleItems<readonly []>, []>>(true);
+
+test('ignore empty test for jest', () => {
+  // ignore
+});

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -594,6 +594,172 @@ describe('types', () => {
       });
     });
 
+    describe('tuple', () => {
+      test('default', () => {
+        const value = types.tuple([
+          types.string(),
+          types.number(),
+          types.boolean(),
+          types.objectId(),
+          types.date(),
+        ] as const);
+
+        expect(value).toEqual({
+          items: [
+            {
+              type: 'string',
+            },
+            {
+              type: 'number',
+            },
+            {
+              type: 'boolean',
+            },
+            {
+              bsonType: 'objectId',
+            },
+            {
+              bsonType: 'date',
+            },
+          ],
+          additionalItems: false,
+          minItems: 0,
+          type: 'array',
+        });
+        expectType<
+          | undefined
+          | []
+          | [string]
+          | [string, number]
+          | [string, number, boolean]
+          | [string, number, boolean, ObjectId]
+          | [string, number, boolean, ObjectId, Date]
+        >(value);
+        expectType<typeof value>(undefined);
+      });
+
+      test('required', () => {
+        const value = types.tuple(
+          [
+            types.string(),
+            types.number(),
+            types.boolean(),
+            types.objectId(),
+            types.date(),
+          ] as const,
+          { required: true }
+        );
+
+        expect(value).toEqual({
+          items: [
+            {
+              type: 'string',
+            },
+            {
+              type: 'number',
+            },
+            {
+              type: 'boolean',
+            },
+            {
+              bsonType: 'objectId',
+            },
+            {
+              bsonType: 'date',
+            },
+          ],
+          $required: true,
+          additionalItems: false,
+          minItems: 0,
+          type: 'array',
+        });
+        expectType<
+          | []
+          | [string]
+          | [string, number]
+          | [string, number, boolean]
+          | [string, number, boolean, ObjectId]
+          | [string, number, boolean, ObjectId, Date]
+        >(value);
+        // @ts-expect-error `value` should not be undefined
+        expectType<typeof value>(undefined);
+      });
+
+      test('with required properties', () => {
+        const value = types.tuple(
+          [
+            types.string({ required: true }),
+            types.number({ required: true }),
+            types.boolean({ required: true }),
+            types.objectId(),
+            types.date(),
+          ] as const,
+          { required: true }
+        );
+
+        expect(value).toEqual({
+          items: [
+            { $required: true, type: 'string' },
+            { $required: true, type: 'number' },
+            { $required: true, type: 'boolean' },
+            {
+              bsonType: 'objectId',
+            },
+            {
+              bsonType: 'date',
+            },
+          ],
+          $required: true,
+          additionalItems: false,
+          minItems: 3,
+          type: 'array',
+        });
+        expectType<
+          | [string, number, boolean]
+          | [string, number, boolean, ObjectId]
+          | [string, number, boolean, ObjectId, Date]
+        >(value);
+      });
+
+      test('with required properties and preceding optional properties', () => {
+        const value = types.tuple(
+          [
+            types.string(),
+            types.number(),
+            types.boolean(),
+            types.objectId({ required: true }),
+            types.date(),
+          ] as const,
+          { required: true }
+        );
+
+        expect(value).toEqual({
+          items: [
+            {
+              type: 'string',
+            },
+            {
+              type: 'number',
+            },
+            {
+              type: 'boolean',
+            },
+            { $required: true, bsonType: 'objectId' },
+            {
+              bsonType: 'date',
+            },
+          ],
+          $required: true,
+          additionalItems: false,
+          minItems: 4,
+          type: 'array',
+        });
+        expectType<[string, number, boolean, ObjectId] | [string, number, boolean, ObjectId, Date]>(
+          value
+        );
+      });
+    });
+
     describe('unknown', () => {
       test('default', () => {
         const value = types.unknown();


### PR DESCRIPTION
Adds a tuple type with optional property support.

In order to have our return type match the [JSON Schema implementation of tuples](https://json-schema.org/understanding-json-schema/reference/array.html#tuple-validation) we're leveraging the `minItems` property, setting it to the position of the last required property defined in the tuple.

If there are properties preceding a required property in the tuple they are implicitly required as well, because the order of a tuple array is ensured and we cannot require a 3rd property while allowing optional 1st and 2nd properties.

The return type is tuple of all required properties in a union with each additional type including the next tuple property in order.