### PR TITLE
feat: Add `Model.exists(filter)` query helper

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -410,6 +410,31 @@ Calls the MongoDB [`updateOne()`](https://mongodb.github.io/node-mongodb-native/
 const result = await User.updateOne({ firstName: 'John' }, { $set: { age: 40 } });
 ```
 
+## `exists`
+
+Performs an optimized `find` to test for the existence of any document matching the filter criteria.
+
+**Parameters:**
+
+| Name      | Type                                      | Attribute |
+| --------- | ----------------------------------------- | --------- | ------ | --------- | -------- |
+| `filter`  | `Filter<TSchema>`                         | required  |
+| `options` | `Omit<FindOptions<TSchema>, ("projection" | "limit"   | "sort" | "skip")>` | optional |
+
+**Returns:**
+
+`Promise<boolean>`
+
+**Example:**
+
+```ts
+const isAlreadyActive = await User.exists({
+  firstName: 'John',
+  lastName: 'Wick',
+  active: true,
+});
+```
+
 ## `upsert`
 
 Calls the MongoDB [`findOneAndUpdate()`](https://mongodb.github.io/node-mongodb-native/4.1/classes/Collection.html#findOneAndUpdate) method with the `upsert` option enabled.

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -416,10 +416,10 @@ Performs an optimized `find` to test for the existence of any document matching 
 
 **Parameters:**
 
-| Name      | Type                                      | Attribute |
-| --------- | ----------------------------------------- | --------- | ------ | --------- | -------- |
-| `filter`  | `Filter<TSchema>`                         | required  |
-| `options` | `Omit<FindOptions<TSchema>, ("projection" | "limit"   | "sort" | "skip")>` | optional |
+| Name      | Type                                                                        | Attribute |
+| --------- | --------------------------------------------------------------------------- | --------- |
+| `filter`  | `Filter<TSchema>`                                                           | required  |
+| `options` | `Omit<FindOptions<TSchema>, ("projection" \| "limit" \| "sort" \| "skip")>` | optional  |
 
 **Returns:**
 

--- a/docs/build.js
+++ b/docs/build.js
@@ -51,7 +51,7 @@ function transpileTS(tsCode) {
   return result.outputText;
 }
 
-function type(names) {
+function formatType(names) {
   return names.map((name) =>
     name
       .replace(/\.</g, '<')
@@ -60,24 +60,34 @@ function type(names) {
   );
 }
 
+function asInlineCodeBlock(str) {
+  return `\`${str}\``;
+}
+
 function getParameters(params) {
   const header = '| Name | Type | Attribute |';
   const separator = '| --- | --- | --- |';
 
   const rows = params
-    .map(
-      (param) =>
-        `| \`${param.name}\` | \`${type(param.type.names).join(' \\| ')}\` | ${
-          param.optional ? 'optional' : 'required'
-        } |`
-    )
+    .map((param) => {
+      const name = asInlineCodeBlock(param.name);
+      const typeNames = formatType(param.type.names).map(
+        // Escape pipe characters that aren't already escaped;
+        // otherwise they are considered as a table column delimiter
+        // by the prettier table formatter.
+        (name) => name.replace(/(?<!\\)\|/g, '\\|')
+      );
+      const type = asInlineCodeBlock(typeNames.join(' \\| '));
+      const optional = param.optional ? 'optional' : 'required';
+      return `| ${name} | ${type} | ${optional} |`;
+    })
     .join('\n');
 
   return `${header}\n${separator}\n${rows}`;
 }
 
 function getReturns(returns) {
-  const value = `\`${type(returns.type.names).join('')}\``;
+  const value = `\`${formatType(returns.type.names).join('')}\``;
   const description = returns.description || '';
   const isURL = description.match(/^https:/);
 

--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -815,6 +815,13 @@ describe('model', () => {
     });
   });
 
+  describe('exists', () => {
+    test('default', async () => {
+      const result = await simpleModel.exists({ bar: 123 });
+      expectType<boolean>(result);
+    });
+  });
+
   describe('find', () => {
     test('default', async () => {
       const results = await simpleModel.find({});


### PR DESCRIPTION
There's a little bit of nuance to getting the most performance out of a
query when you only care checking if there exists a row matching a given
query. This helper tries its best to query the DB in the most performant
way, and returns a boolean result.

Performance Notes:
- The query used is a `findOne`. The query engine can then start scanning and stop
  as soon as it matches a single document.

- Project out a single column from the filter criteria (or project `_id`
  if there is no filter). In this way we return a minimum of data, while
  potentially allowing this to be a "covered" query if there is an index
  that includes all the keys in the filter.