### PR TITLE
feat: Allow user definition of `_id` property type

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -209,10 +209,10 @@ The result type (`TProjected`) takes into account the projection for this query 
 
 **Parameters:**
 
-| Name      | Type                   | Attribute |
-| --------- | ---------------------- | --------- |
-| `id`      | `string \| ObjectId`   | required  |
-| `options` | `FindOptions<TSchema>` | optional  |
+| Name      | Type                    | Attribute |
+| --------- | ----------------------- | --------- |
+| `id`      | `string \| TSchema._id` | required  |
+| `options` | `FindOptions<TSchema>`  | optional  |
 
 **Returns:**
 

--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -68,16 +68,35 @@ describe('model', () => {
     }
   );
 
+  const numericIdSchema = schema(
+    {
+      _id: Types.number({ required: true }),
+      bar: Types.number({ required: true }),
+      foo: Types.string({ required: true }),
+      ham: Types.date(),
+      nested: Types.object({
+        direct: Types.string({ required: true }),
+        other: Types.number(),
+      }),
+    },
+    {
+      defaults: DEFAULTS,
+    }
+  );
+
   type SimpleDocument = typeof simpleSchema[0];
   type SimpleOptions = typeof simpleSchema[1];
   type TimestampsDocument = typeof timestampsSchema[0];
   type TimestampsOptions = typeof timestampsSchema[1];
   type TimestampConfigDocument = typeof timestampConfigSchema[0];
   type TimestampConfigOptions = typeof timestampConfigSchema[1];
+  type NumericIdDocument = typeof numericIdSchema[0];
+  type NumericIdOptions = typeof numericIdSchema[1];
 
   let simpleModel: Model<SimpleDocument, SimpleOptions>;
   let timestampsModel: Model<TimestampsDocument, TimestampsOptions>;
   let timestampConfigModel: Model<TimestampConfigDocument, TimestampConfigOptions>;
+  let numericIdModel: Model<NumericIdDocument, NumericIdOptions>;
 
   let doc: SimpleDocument;
   let docs: SimpleDocument[];
@@ -163,6 +182,11 @@ describe('model', () => {
     timestampConfigModel = abstract(timestampConfigSchema);
     // @ts-expect-error Ignore schema types
     build(timestampConfigSchema, timestampConfigModel, collection);
+
+    // @ts-expect-error Ignore abstract assignment
+    numericIdModel = abstract(numericIdSchema);
+    // @ts-expect-error Ignore schema types
+    build(numericIdSchema, numericIdModel, collection);
   });
 
   describe('aggregate', () => {
@@ -893,6 +917,16 @@ describe('model', () => {
         result.bar;
         expectType<Date | undefined>(result.ham);
       }
+    });
+
+    test('with a numeric _id', async () => {
+      const result = await numericIdModel.findById(1, { projection });
+
+      expectType<{
+        _id: number;
+        foo: string;
+        ham?: Date;
+      } | null>(result);
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -104,7 +104,7 @@ export type ProjectionType<
   Projection extends Partial<Record<Join<NestedPaths<WithId<TSchema>>, '.'>, number>> | undefined
 > = undefined extends Projection
   ? WithId<TSchema>
-  : WithId<DeepPick<TSchema, keyof Projection & string>>;
+  : WithId<DeepPick<TSchema, '_id' | (keyof Projection & string)>>;
 
 export type Projection<TSchema> = Partial<Record<Join<NestedPaths<WithId<TSchema>>, '.'>, number>>;
 


### PR DESCRIPTION
Rather than exclusively requiring all `_id` properties be an ObjectId, we can allow for users to define their own `_id` in their schema and have it reflected when using `model.findById`.

This also updates `ProjectionType` to facilitate non-ObjectId `_id` properties. The resulting type for models _with_ ObjectId `_id` properties is unchanged, so I don't consider this breaking.

Effectively, when constructing our `ProjectionType` we're picking properties defined in our projection from `TSchema` - this means excluding the `_id` property (unless explicitly set in the projection). However, we then use the `mongodb` supplied generic `WithId` to add the `_id` property back in, since it is always included in projected results.

This is where the issue lies - because the `WithId` generic uses the passed schema value to determine the `_id` type, with `ObjectId` as a default. So when we pass our `TSchema` with the `_id` property excluded, we always end up with the default value from `WithId` - an `ObjectId`. By including `_id` along with projection keys, the type supplied to `WithId` is able to appropriately detect the `_id` property type.