### PR TITLE
fix: Correct `oneOf` required option

### DIFF
--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -501,6 +501,8 @@ describe('schema', () => {
           },
           { required: true }
         ),
+        oneOfOptional: types.oneOf([types.number(), types.string()]),
+        oneOfRequired: types.oneOf([types.number(), types.string()], { required: true }),
         stringOptional: types.string(),
         stringRequired: types.string({ required: true }),
       },
@@ -651,6 +653,26 @@ describe('schema', () => {
           },
           type: 'object',
         },
+        oneOfOptional: {
+          oneOf: [
+            {
+              type: 'number',
+            },
+            {
+              type: 'string',
+            },
+          ],
+        },
+        oneOfRequired: {
+          oneOf: [
+            {
+              type: 'number',
+            },
+            {
+              type: 'string',
+            },
+          ],
+        },
         stringOptional: {
           type: 'string',
         },
@@ -673,6 +695,7 @@ describe('schema', () => {
         'objectGenericRequired',
         'objectIdRequired',
         'objectRequired',
+        'oneOfRequired',
         'stringRequired',
         'createdAt',
         'updatedAt',
@@ -707,6 +730,8 @@ describe('schema', () => {
       objectIdRequired: ObjectId;
       objectOptional?: { foo?: number };
       objectRequired: { foo?: number };
+      oneOfOptional?: number | string;
+      oneOfRequired: number | string;
       stringOptional?: string;
       stringRequired: string;
       createdAt: Date;
@@ -809,6 +834,8 @@ describe('schema', () => {
           },
           { required: true }
         ),
+        oneOfOptional: types.oneOf([types.number(), types.string()]),
+        oneOfRequired: types.oneOf([types.number(), types.string()], { required: true }),
         stringOptional: types.string({ required: false }),
         stringRequired: types.string({ required: true }),
       },
@@ -959,6 +986,26 @@ describe('schema', () => {
           },
           type: 'object',
         },
+        oneOfOptional: {
+          oneOf: [
+            {
+              type: 'number',
+            },
+            {
+              type: 'string',
+            },
+          ],
+        },
+        oneOfRequired: {
+          oneOf: [
+            {
+              type: 'number',
+            },
+            {
+              type: 'string',
+            },
+          ],
+        },
         stringOptional: {
           type: 'string',
         },
@@ -981,6 +1028,7 @@ describe('schema', () => {
         'objectGenericRequired',
         'objectIdRequired',
         'objectRequired',
+        'oneOfRequired',
         'stringRequired',
         'createdAt',
         'updatedAt',
@@ -1015,6 +1063,8 @@ describe('schema', () => {
       objectIdRequired: ObjectId;
       objectOptional?: { foo?: number };
       objectRequired: { foo?: number };
+      oneOfOptional?: number | string;
+      oneOfRequired: number | string;
       stringOptional?: string;
       stringRequired: string;
       createdAt: Date;

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -842,32 +842,33 @@ describe('types', () => {
         expectType<typeof value>('foo');
         expectType<typeof value>(undefined);
       });
-    });
 
-    test('required', () => {
-      const value = types.oneOf([types.boolean(), types.string()], { required: true });
+      test('required', () => {
+        const value = types.oneOf([types.boolean(), types.string()], { required: true });
 
-      expect(value).toEqual(
-        expect.objectContaining({
-          oneOf: [
-            {
-              $required: true,
-              type: 'boolean',
-            },
-            {
-              $required: true,
-              type: 'string',
-            },
-          ],
-        })
-      );
-      expectType<boolean | string>(value);
-      // @ts-expect-error `value` should not be `number`
-      expectType<number>(value);
-      // @ts-expect-error `value` should not be `undefined`
-      expectType<undefined>(value);
-      expectType<typeof value>(true);
-      expectType<typeof value>('foo');
+        expect(value).toEqual(
+          expect.objectContaining({
+            $required: true,
+            oneOf: [
+              {
+                $required: true,
+                type: 'boolean',
+              },
+              {
+                $required: true,
+                type: 'string',
+              },
+            ],
+          })
+        );
+        expectType<boolean | string>(value);
+        // @ts-expect-error `value` should not be `number`
+        expectType<number>(value);
+        // @ts-expect-error `value` should not be `undefined`
+        expectType<undefined>(value);
+        expectType<typeof value>(true);
+        expectType<typeof value>('foo');
+      });
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,6 +205,7 @@ export function oneOf<Types extends any[], Options extends GenericOptions>(
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return {
+    ...(required ? { $required: true } : {}),
     oneOf: required
       ? // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         types.map((type) => ({


### PR DESCRIPTION
When adding a test case in #312 I noticed that while we're correctly typing the output of required `oneOf` types, it doesn't match the underlying JSON schema implementation.

Currently the resulting property is always optional at the schema level - by adding the `$required: true` to the return object from the `oneOf` type function we ensure that the property is included in the `required` properties array and is validated appropriately by mongo on insert.

BREAKING CHANGE: This changes the produced JSON schema for required `oneOf` types to correctly include it in the resulting `required` properties array.