### PR TITLE
feat: Util getIds accepts readonly structures

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,7 +126,7 @@ export type RequireAtLeastOne<TObj, Keys extends keyof TObj = keyof TObj> = Pick
     [Key in Keys]-?: Required<Pick<TObj, Key>> & Partial<Pick<TObj, Exclude<Keys, Key>>>;
   }[Keys];
 
-export function getIds(ids: (string | ObjectId)[] | Set<string>): ObjectId[] {
+export function getIds(ids: readonly (string | ObjectId)[] | Set<string>): ObjectId[] {
   return [...ids].map((id) => new ObjectId(id));
 }
 


### PR DESCRIPTION
`getIds` performs no transformation on incoming parameters.

By accepting `readonly` arrays of strings it is able to handle a wider variety of inputs.
By continuing to return a mutable array of ObjectIds, no existing consumers should be affected.