### PR TITLE
test: Fix CI dependency

### DIFF
--- a/tests/cjs/package.json
+++ b/tests/cjs/package.json
@@ -2,7 +2,7 @@
   "type": "commonjs",
   "dependencies": {
     "papr": "file:../../build/package",
-    "mongodb": "4.0.0"
+    "mongodb": "4.11.0"
   },
   "volta": {
     "node": "14.16.0",

--- a/tests/esm/package.json
+++ b/tests/esm/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "dependencies": {
     "papr": "file:../../build/package",
-    "mongodb": "4.0.0"
+    "mongodb": "4.11.0"
   },
   "volta": {
     "node": "14.16.0",


### PR DESCRIPTION
The build tests have started failing because the `mongodb` dependency in the build test `package.json` files were still using version `4.0.0`, even though our package requires `>=4.11.0`. This must be a new behavior in the `npm` client used to install that.