### PR TITLE
feat: Type check nested objects in generic objects

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,8 +173,12 @@ export type PropertyType<Type, Property extends string> = string extends Propert
   ? unknown
   : // object properties
   Property extends keyof Type
-  ? Type[Property]
-  : NonNullable<Type> extends readonly (infer ArrayType)[]
+  ? Type extends Record<string, any>
+    ? Property extends `${string}.${string}`
+      ? PropertyNestedType<NonNullable<Type>, Property>
+      : Type[Property]
+    : Type[Property]
+  : Type extends readonly (infer ArrayType)[]
   ? // indexed array properties
     Property extends `${number}`
     ? ArrayType


### PR DESCRIPTION
This PR adds support for type checking nested fields in a generic object (e.g. `Record<string, object>`).

Given a schema containing this field:

```ts
foo: Types.objectGeneric(Types.object({
  title: Types.string()
}, { required: true }));
```

We can now write type checked filters:

```ts
await Test.find({ 'foo.any-key.title': 'Test title' });
```