### PR TITLE
feat: Add `forEach` model method

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -343,6 +343,32 @@ userProjected.firstName; // TypeScript error
 userProjected.lastName; // valid
 ```
 
+## `forEach`
+
+Iterates over a result set, passing each found row into the iterator
+function.
+
+Useful when you want to process many rows without loading them all into
+memory at once.
+
+If the iterator function returns `false`, no more rows will be processed.
+
+**Parameters:**
+
+| Name       | Type                   | Attribute |
+| ---------- | ---------------------- | --------- |
+| `filter`   | `PaprFilter<TSchema>`  | required  |
+| `options`  | `FindOptions<TSchema>` | optional  |
+| `iterator` | `function`             | required  |
+
+**Example:**
+
+```ts
+User.forEach({ active: true, email: { $exists: true } }, { projection: { email: 1 } }, (row) =>
+  notify(row.email)
+);
+```
+
 ## `insertMany`
 
 Calls the MongoDB [`insertMany()`](https://mongodb.github.io/node-mongodb-native/5.0/classes/Collection.html#insertMany) method.

--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -125,6 +125,8 @@ describe('model', () => {
       // @ts-expect-error Ignore mock function
       find: jest.fn().mockReturnValue({
         // @ts-expect-error Ignore mock function
+        forEach: jest.fn().mockResolvedValue(undefined),
+        // @ts-expect-error Ignore mock function
         toArray: jest.fn().mockResolvedValue(docs),
       }),
       // @ts-expect-error Ignore mock function
@@ -1392,6 +1394,35 @@ describe('model', () => {
           }
         );
       });
+    });
+  });
+
+  describe('forEach', () => {
+    test('default', async () => {
+      await simpleModel.forEach({}, (row) => {
+        expectType<SimpleDocument>(row);
+      });
+    });
+
+    test('with projection', async () => {
+      await simpleModel.forEach({}, { projection }, (row) => {
+        expectType<{
+          _id: ObjectId;
+          foo: string;
+          ham?: Date;
+        }>(row);
+        // @ts-expect-error `bar` is undefined here
+        row.bar;
+      });
+    });
+
+    test('throws error with invalid argument shape', async () => {
+      await expect(
+        // @ts-expect-error avoid type error here to force runtime error
+        simpleModel.forEach({}, {}, {}, (row) => {
+          expectType<SimpleDocument>(row);
+        })
+      ).rejects.toThrow('Invalid argument shape supplied to forEach');
     });
   });
 


### PR DESCRIPTION
Adds a method allowing us to iterate over results without loading them all into memory at once.

This is also the first overloaded model method in the Papr library 🎉.