### PR TITLE
feat: Add `findCursor` model method

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -260,6 +260,33 @@ userProjected.firstName; // TypeScript error
 userProjected.lastName; // valid
 ```
 
+## `findCursor`
+
+Calls the MongoDB [`find()`](https://mongodb.github.io/node-mongodb-native/5.0/classes/Collection.html#find) method and returns the cursor.
+
+Useful when you want to process many records without loading them all into
+memory at once.
+
+**Parameters:**
+
+| Name      | Type                   | Attribute |
+| --------- | ---------------------- | --------- |
+| `filter`  | `PaprFilter<TSchema>`  | required  |
+| `options` | `FindOptions<TSchema>` | optional  |
+
+**Example:**
+
+```ts
+const cursor = await User.findCursor(
+  { active: true, email: { $exists: true } },
+  { projection: { email: 1 } }
+);
+
+for await (const user of cursor) {
+  await notify(user.email);
+}
+```
+
 ## `findOne`
 
 Calls the MongoDB [`findOne()`](https://mongodb.github.io/node-mongodb-native/5.0/classes/Collection.html#findOne) method.

--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
-import { Collection, MongoError, ObjectId } from 'mongodb';
+import { Collection, FindCursor, MongoError, ObjectId } from 'mongodb';
 import { expectType } from 'ts-expect';
 import { Hooks } from '../hooks';
 import { abstract, build, Model } from '../model';
@@ -899,6 +899,37 @@ describe('model', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       results = testProjected(results);
+    });
+  });
+
+  describe('findCursor', () => {
+    test('default', async () => {
+      const cursor = await simpleModel.findCursor({});
+
+      expectType<FindCursor<SimpleDocument>>(cursor);
+    });
+
+    test('with projection', async () => {
+      const cursor = await simpleModel.findCursor(
+        {},
+        {
+          projection: {
+            ...projection,
+            'nested.direct': 1,
+          },
+        }
+      );
+
+      expectType<
+        FindCursor<{
+          _id: ObjectId;
+          foo: string;
+          ham?: Date;
+          nested?: {
+            direct: string;
+          };
+        }>
+      >(cursor);
     });
   });
 


### PR DESCRIPTION
This returns the mongodb `FindCursor` allowing users to handle iteration however they please in their applications without loading all results into memory at once.

This is an alternative to #453. In my opinion this implementation is better suited to the idea of Papr being a thin wrapper around the MongoDB driver.