### PR TITLE
refactor: Perform no-op on `bulkWrite` when no operations provided

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -52,6 +52,9 @@ const results = await User.aggregate<{ age: number }>([
 
 Calls the MongoDB [`bulkWrite()`](https://mongodb.github.io/node-mongodb-native/5.0/classes/Collection.html#bulkWrite) method.
 
+If no operations are provided this method acts as a no-op and return
+nothing.
+
 **Parameters:**
 
 | Name         | Type                                           | Attribute |
@@ -61,7 +64,7 @@ Calls the MongoDB [`bulkWrite()`](https://mongodb.github.io/node-mongodb-native/
 
 **Returns:**
 
-[`Promise<BulkWriteResult>`](https://mongodb.github.io/node-mongodb-native/5.0/classes/BulkWriteResult.html)
+[`Promise<(BulkWriteResult | void)>`](https://mongodb.github.io/node-mongodb-native/5.0/classes/BulkWriteResult.html)
 
 **Example:**
 

--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -800,6 +800,12 @@ describe('model', () => {
         },
       ]);
     });
+
+    test('with empty operations array', async () => {
+      await simpleModel.bulkWrite([]);
+
+      expect(collection.bulkWrite).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('distinct', () => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -57,7 +57,7 @@ export interface Model<TSchema extends BaseSchema, TOptions extends SchemaOption
   bulkWrite: (
     operations: PaprBulkWriteOperation<TSchema, TOptions>[],
     options?: BulkWriteOptions
-  ) => Promise<BulkWriteResult>;
+  ) => Promise<BulkWriteResult | void>;
 
   countDocuments: (filter: PaprFilter<TSchema>, options?: CountDocumentsOptions) => Promise<number>;
 
@@ -336,10 +336,13 @@ export function build<TSchema extends BaseSchema, TOptions extends SchemaOptions
    *
    * Calls the MongoDB [`bulkWrite()`](https://mongodb.github.io/node-mongodb-native/5.0/classes/Collection.html#bulkWrite) method.
    *
+   * If no operations are provided this method acts as a no-op and return
+   * nothing.
+   *
    * @param operations {Array<BulkWriteOperation<TSchema, TOptions>>}
    * @param [options] {BulkWriteOptions}
    *
-   * @returns {Promise<BulkWriteResult>} https://mongodb.github.io/node-mongodb-native/5.0/classes/BulkWriteResult.html
+   * @returns {Promise<BulkWriteResult | void>} https://mongodb.github.io/node-mongodb-native/5.0/classes/BulkWriteResult.html
    *
    * @example
    * const results = await User.bulkWrite([
@@ -366,7 +369,10 @@ export function build<TSchema extends BaseSchema, TOptions extends SchemaOptions
     async function bulkWrite(
       operations: PaprBulkWriteOperation<TSchema, TOptions>[],
       options?: BulkWriteOptions
-    ): Promise<BulkWriteResult> {
+    ): Promise<BulkWriteResult | void> {
+      if (operations.length === 0) {
+        return;
+      }
       const finalOperations = operations.map((op) => {
         let operation = op;
         if ('insertOne' in op) {


### PR DESCRIPTION
As @ejmartin504 discussed in #272 - rather than throwing when an empty array is passed to `model.bulkWrite` we can perform a no-op and exit early. 

BREAKING CHANGE: Changes the return type of `model.bulkWrite` to include `void`
    
Closes #272