### PR TITLE
refactor: Remove node.js v14 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14.x, 16.x, 18.x, 20.x]
+        node: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Use Node.js ${{ matrix.node }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
+  "search.exclude": {
+    ".yarn/releases/*": true,
+    "yarn.lock": true
+  },
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-_Prerequisites:_ [MongoDB](https://www.mongodb.com/) server (v3.6+) and [NodeJS](https://nodejs.org/) (v14+) installed.
+_Prerequisites:_ [MongoDB](https://www.mongodb.com/) server (v3.6+) and [NodeJS](https://nodejs.org/) (v16+) installed.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": "^14.0.0 || >=15.0.0"
+    "node": ">=16.0.0"
   },
   "type": "module",
   "types": "./esm/index.d.ts",
@@ -61,7 +61,7 @@
     "@byu-oit/bar-chart": "1.4.2",
     "@commitlint/cli": "17.5.1",
     "@commitlint/config-conventional": "17.4.4",
-    "@types/node": "14.18.37",
+    "@types/node": "16.18.32",
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",
     "arg": "5.0.2",
@@ -121,7 +121,7 @@
     "trailingComma": "es5"
   },
   "volta": {
-    "node": "14.21.3",
+    "node": "16.20.0",
     "yarn": "1.22.19"
   },
   "packageManager": "yarn@3.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3086,10 +3086,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:14.18.37":
-  version: 14.18.37
-  resolution: "@types/node@npm:14.18.37"
-  checksum: d21e8c58ddd01ae069b196c2a4eaf9c9749e6666565349667334c60cfc119c1fa280234a8001157dd7ffe73501ce4f4940ca05f9d5c402c5abe78c8dca8376a6
+"@types/node@npm:16.18.32":
+  version: 16.18.32
+  resolution: "@types/node@npm:16.18.32"
+  checksum: c5966c8e671205b2971ae66ae548ce92235cef89ae1a0f2ecbf118e775923259dc85f57c58cfc56267089d56dfce967700c058276199c6ed9510d0a0b077af2d
   languageName: node
   linkType: hard
 
@@ -9341,7 +9341,7 @@ __metadata:
     "@byu-oit/bar-chart": 1.4.2
     "@commitlint/cli": 17.5.1
     "@commitlint/config-conventional": 17.4.4
-    "@types/node": 14.18.37
+    "@types/node": 16.18.32
     "@typescript-eslint/eslint-plugin": 5.54.0
     "@typescript-eslint/parser": 5.54.0
     arg: 5.0.2


### PR DESCRIPTION
BREAKING CHANGE: Node.js v14 is not supported.

This old node.js version is currently in "Maintenance" mode. Let's remove support in the next release.