### PR TITLE
feat: Support dynamic default values

### DIFF
--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -20,14 +20,14 @@ The options are exported as a result type (the second value in the return tuple)
 
 **Parameters:**
 
-| Name                       | Type                      | Attribute |
-| -------------------------- | ------------------------- | --------- |
-| `properties`               | `Record<string, unknown>` | required  |
-| `options`                  | `SchemaOptions`           | optional  |
-| `options.defaults`         | `Partial<TProperties>`    | optional  |
-| `options.timestamps`       | `TimestampSchemaOptions`  | optional  |
-| `options.validationAction` | `VALIDATION_ACTIONS`      | optional  |
-| `options.validationLevel`  | `VALIDATION_LEVEL`        | optional  |
+| Name                       | Type                          | Attribute |
+| -------------------------- | ----------------------------- | --------- |
+| `properties`               | `Record<string, unknown>`     | required  |
+| `options`                  | `SchemaOptions`               | optional  |
+| `options.defaults`         | `DefaultsOption<TProperties>` | optional  |
+| `options.timestamps`       | `TimestampSchemaOptions`      | optional  |
+| `options.validationAction` | `VALIDATION_ACTIONS`          | optional  |
+| `options.validationLevel`  | `VALIDATION_LEVEL`            | optional  |
 
 **Returns:**
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -87,7 +87,13 @@ const exampleSchema = schema(
 
 ### Default Values
 
-Papr does not support dynamic default values, but static default values can be used. Unlike Mongoose where default values are defined in the individual property options, Papr defines defaults in the schema options. An example of this can be seen below.
+Unlike Mongoose where default values are defined in the individual property options, Papr defines defaults in the schema options.
+
+Note: Default values are only applied to paths where no value is set at the time of insert.
+
+#### Static Default Values
+
+To set defaults you can supply an object in your schema with static values.
 
 ```js
 import mongoose from 'mongoose';
@@ -109,6 +115,34 @@ const exampleSchema = schema(
     defaults: {
       switch: false,
     },
+  }
+);
+```
+
+#### Dynamic Default Values
+
+Rather than supplying an object with your default values you can supply a function which will be executed at the time of insert and the returned values used as defaults.
+
+```js
+import mongoose from 'mongoose';
+const { Schema } = mongoose;
+
+const exampleSchema = new Schema({
+  birthday: { type: Date, default: Date.now, required: true },
+});
+```
+
+```ts
+import { schema, types } from 'papr';
+
+const exampleSchema = schema(
+  {
+    birthday: types.date({ required: true }),
+  },
+  {
+    defaults: () => ({
+      birthday: new Date(),
+    }),
   }
 );
 ```

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -15,8 +15,10 @@ export type SchemaTimestampOptions =
     }>
   | boolean;
 
+export type DefaultsOption<TProperties> = Partial<TProperties> | (() => Partial<TProperties>);
+
 export interface SchemaOptions<TProperties> {
-  defaults?: Partial<TProperties>;
+  defaults?: DefaultsOption<TProperties>;
   timestamps?: SchemaTimestampOptions;
   validationAction?: VALIDATION_ACTIONS;
   validationLevel?: VALIDATION_LEVEL;
@@ -74,7 +76,7 @@ function sanitize(value: any): void {
  *
  * @param properties {Record<string, unknown>}
  * @param [options] {SchemaOptions}
- * @param [options.defaults] {Partial<TProperties>}
+ * @param [options.defaults] {DefaultsOption<TProperties>}
  * @param [options.timestamps=false] {TimestampSchemaOptions}
  * @param [options.validationAction=VALIDATION_ACTIONS.ERROR] {VALIDATION_ACTIONS}
  * @param [options.validationLevel=VALIDATION_LEVEL.STRICT] {VALIDATION_LEVEL}


### PR DESCRIPTION
This introduces the ability for users to provide a function that returns default values rather than an object with static values. This is useful when you're using an `_id` value other than ObjectId and would like to keep the functionality of automatically generating an `_id` value on insert.

We continue with the existing behavior of only applying the default value for a path when the path is not included in the insert. This isn't technically a breaking change since all schemas will continue to work as expected.

Closes: plexinc/papr#18