### PR TITLE
feat: Upgrade mongodb to v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=16.20.1"
   },
   "type": "module",
   "types": "./esm/index.d.ts",
@@ -77,7 +77,7 @@
     "jsdoc-api": "8.0.0",
     "jsdoc-parse": "6.2.0",
     "lint-staged": "14.0.0",
-    "mongodb": "5.8.0",
+    "mongodb": "6.0.0",
     "mongodb-memory-server": "8.15.1",
     "mongoose": "6.3.5",
     "pinst": "3.0.0",
@@ -88,7 +88,7 @@
     "typescript": "5.2.2"
   },
   "peerDependencies": {
-    "mongodb": "^5.0.0"
+    "mongodb": "^6.0.0"
   },
   "commitlint": {
     "extends": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ devDependencies:
     specifier: 14.0.0
     version: 14.0.0
   mongodb:
-    specifier: 5.8.0
-    version: 5.8.0
+    specifier: 6.0.0
+    version: 6.0.0
   mongodb-memory-server:
     specifier: 8.15.1
     version: 8.15.1
@@ -2371,7 +2371,6 @@ packages:
     dependencies:
       sparse-bitfield: 3.0.3
     dev: true
-    optional: true
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3583,9 +3582,9 @@ packages:
       buffer: 5.7.1
     dev: true
 
-  /bson@5.4.0:
-    resolution: {integrity: sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==}
-    engines: {node: '>=14.20.1'}
+  /bson@6.0.0:
+    resolution: {integrity: sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg==}
+    engines: {node: '>=16.20.1'}
     dev: true
 
   /buffer-crc32@0.2.13:
@@ -6690,7 +6689,6 @@ packages:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
     requiresBuild: true
     dev: true
-    optional: true
 
   /meow@8.1.2:
     resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==}
@@ -6855,19 +6853,23 @@ packages:
       saslprep: 1.0.3
     dev: true
 
-  /mongodb@5.8.0:
-    resolution: {integrity: sha512-xx4CXmxcj3bNe7iGBlhntVrUqrNARYhUZteXaz4epEESv4oXD/FONAovcyoCaEffdYlw25Yz284OxMfpnPLlgQ==}
-    engines: {node: '>=14.20.1'}
+  /mongodb@6.0.0:
+    resolution: {integrity: sha512-wUIYesF4DTyDccm0noE5TwGi9ISdXUAi9T2cQ4xPc+EUBZG44bfMVt2ecOG5Ypca7eCz3oRpJm6YI6c7jAnuNw==}
+    engines: {node: '>=16.20.1'}
     peerDependencies:
       '@aws-sdk/credential-providers': ^3.188.0
-      '@mongodb-js/zstd': ^1.0.0
-      kerberos: ^1.0.0 || ^2.0.0
-      mongodb-client-encryption: '>=2.3.0 <3'
+      '@mongodb-js/zstd': ^1.1.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
       snappy: ^7.2.2
+      socks: ^2.7.1
     peerDependenciesMeta:
       '@aws-sdk/credential-providers':
         optional: true
       '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
         optional: true
       kerberos:
         optional: true
@@ -6875,12 +6877,12 @@ packages:
         optional: true
       snappy:
         optional: true
+      socks:
+        optional: true
     dependencies:
-      bson: 5.4.0
-      mongodb-connection-string-url: 2.6.0
-      socks: 2.7.1
-    optionalDependencies:
       '@mongodb-js/saslprep': 1.1.0
+      bson: 6.0.0
+      mongodb-connection-string-url: 2.6.0
     dev: true
 
   /mongoose@6.3.5:
@@ -7874,7 +7876,6 @@ packages:
     dependencies:
       memory-pager: 1.5.0
     dev: true
-    optional: true
 
   /spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}

--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -150,15 +150,9 @@ describe('model', () => {
       // @ts-expect-error Ignore mock function
       findOne: jest.fn().mockResolvedValue(doc),
       // @ts-expect-error Ignore mock function
-      findOneAndDelete: jest.fn().mockResolvedValue({
-        ok: 1,
-        value: doc,
-      }),
+      findOneAndDelete: jest.fn().mockResolvedValue(doc),
       // @ts-expect-error Ignore mock function
-      findOneAndUpdate: jest.fn().mockResolvedValue({
-        ok: 1,
-        value: doc,
-      }),
+      findOneAndUpdate: jest.fn().mockResolvedValue(doc),
       // @ts-expect-error Ignore mock function
       insertMany: jest.fn().mockResolvedValue({
         acknowledged: true,
@@ -1235,11 +1229,9 @@ describe('model', () => {
     });
 
     test('throws error on failure', async () => {
-      (collection.findOneAndDelete as jest.Mocked<Collection['findOneAndDelete']>)
-        // @ts-expect-error Ignore mock value
-        .mockResolvedValue({
-          ok: 0,
-        });
+      (
+        collection.findOneAndDelete as jest.Mocked<Collection['findOneAndDelete']>
+      ).mockRejectedValueOnce(new Error('findOneAndDelete failed'));
 
       await expect(simpleModel.findOneAndDelete({ foo: 'bar' })).rejects.toThrow(
         'findOneAndDelete failed'
@@ -1288,9 +1280,9 @@ describe('model', () => {
     });
 
     test('throws error on failure', async () => {
-      (collection.findOneAndUpdate as jest.Mocked<Collection['findOneAndUpdate']>)
-        // @ts-expect-error Ignore mock value
-        .mockResolvedValue({ ok: 0 });
+      (
+        collection.findOneAndUpdate as jest.Mocked<Collection['findOneAndUpdate']>
+      ).mockRejectedValueOnce(new Error('findOneAndUpdate failed'));
 
       await expect(
         simpleModel.findOneAndUpdate({ foo: 'bar' }, { $set: { bar: 123 } })
@@ -2515,9 +2507,9 @@ describe('model', () => {
     });
 
     test('throws error on failure', async () => {
-      (collection.findOneAndUpdate as jest.Mocked<Collection['findOneAndUpdate']>)
-        // @ts-expect-error Ignore mock function
-        .mockResolvedValue({ ok: false });
+      (
+        collection.findOneAndUpdate as jest.Mocked<Collection['findOneAndUpdate']>
+      ).mockRejectedValueOnce(new Error('findOneAndUpdate failed'));
 
       await expect(simpleModel.upsert({ foo: 'foo' }, { $set: { bar: 123 } })).rejects.toThrow(
         'findOneAndUpdate failed'

--- a/src/__tests__/mongodbTypes.test.ts
+++ b/src/__tests__/mongodbTypes.test.ts
@@ -95,7 +95,7 @@ describe('mongodb types', () => {
         });
 
         // all BSON types can be used as query values
-        expectType<PaprFilter<TestDocument>>({ binary: new Binary('', 2) });
+        expectType<PaprFilter<TestDocument>>({ binary: new Binary([], 2) });
         expectType<PaprFilter<TestDocument>>({ bsonSymbol: new BSONSymbol('hi') });
         expectType<PaprFilter<TestDocument>>({ code: new Code(() => true) });
         expectType<PaprFilter<TestDocument>>({ double: new Double(123.45) });
@@ -509,7 +509,7 @@ describe('mongodb types', () => {
           });
 
           // all BSON types can be used as update values
-          expectType<PaprUpdateFilter<TestDocument>>({ $set: { binary: new Binary('', 2) } });
+          expectType<PaprUpdateFilter<TestDocument>>({ $set: { binary: new Binary([], 2) } });
           expectType<PaprUpdateFilter<TestDocument>>({
             $set: { bsonSymbol: new BSONSymbol('hi') },
           });

--- a/src/model.ts
+++ b/src/model.ts
@@ -779,11 +779,7 @@ export function build<TSchema extends BaseSchema, TOptions extends SchemaOptions
       } as FindOneAndDeleteOptions
     );
 
-    if (result.ok === 1) {
-      return result.value as ProjectionType<TSchema, TProjection>;
-    }
-
-    throw new Error('findOneAndDelete failed');
+    return result as ProjectionType<TSchema, TProjection>;
   });
 
   /**
@@ -848,11 +844,7 @@ export function build<TSchema extends BaseSchema, TOptions extends SchemaOptions
       } as FindOneAndUpdateOptions
     );
 
-    if (result.ok === 1) {
-      return result.value as ProjectionType<TSchema, TProjection>;
-    }
-
-    throw new Error('findOneAndUpdate failed');
+    return result as ProjectionType<TSchema, TProjection>;
   });
 
   /**

--- a/tests/cjs/package.json
+++ b/tests/cjs/package.json
@@ -2,6 +2,6 @@
   "type": "commonjs",
   "dependencies": {
     "papr": "file:../../build/package",
-    "mongodb": "5.1.0"
+    "mongodb": "6.0.0"
   }
 }

--- a/tests/esm/package.json
+++ b/tests/esm/package.json
@@ -2,6 +2,6 @@
   "type": "module",
   "dependencies": {
     "papr": "file:../../build/package",
-    "mongodb": "5.1.0"
+    "mongodb": "6.0.0"
   }
 }

--- a/tests/ts-nodenext/package.json
+++ b/tests/ts-nodenext/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "dependencies": {
     "papr": "file:../../build/package",
-    "mongodb": "5.1.0",
+    "mongodb": "6.0.0",
     "ts-expect": "1.3.0",
     "typescript": "5.0.4"
   }

--- a/tests/ts/package.json
+++ b/tests/ts/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "dependencies": {
     "papr": "file:../../build/package",
-    "mongodb": "5.1.0",
+    "mongodb": "6.0.0",
     "ts-expect": "1.3.0",
     "typescript": "5.0.4"
   }


### PR DESCRIPTION
https://github.com/mongodb/node-mongodb-native/releases/tag/v6.0.0

BREAKING CHANGE: `mongodb` minimum version is now v6.*
    
BREAKING CHANGE: `node` minimum version is now v16.20.1
