### PR TITLE
docs: Typo in bulkWrite description

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -52,7 +52,7 @@ const results = await User.aggregate<{ age: number }>([
 
 Calls the MongoDB [`bulkWrite()`](https://mongodb.github.io/node-mongodb-native/5.0/classes/Collection.html#bulkWrite) method.
 
-If no operations are provided this method acts as a no-op and return
+If no operations are provided this method acts as a no-op and returns
 nothing.
 
 **Parameters:**

--- a/src/model.ts
+++ b/src/model.ts
@@ -344,7 +344,7 @@ export function build<TSchema extends BaseSchema, TOptions extends SchemaOptions
    *
    * Calls the MongoDB [`bulkWrite()`](https://mongodb.github.io/node-mongodb-native/5.0/classes/Collection.html#bulkWrite) method.
    *
-   * If no operations are provided this method acts as a no-op and return
+   * If no operations are provided this method acts as a no-op and returns
    * nothing.
    *
    * @param operations {Array<BulkWriteOperation<TSchema, TOptions>>}


### PR DESCRIPTION
Small typo fix in the documentation.

https://plexinc.github.io/papr/#/api/model?id=bulkwrite

<img width="681" alt="image" src="https://github.com/plexinc/papr/assets/7367/71d2ebcd-65fc-4498-8491-71272f5e2bfc">
