### PR TITLE
fix: Don't exclude null from oneOf return type

### DIFF
--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -956,6 +956,34 @@ describe('types', () => {
         expectType<typeof value>(true);
         expectType<typeof value>('foo');
       });
+
+      test('nullable', () => {
+        const value = types.oneOf([types.string(), types.null()], { required: true });
+
+        expect(value).toEqual(
+          expect.objectContaining({
+            $required: true,
+            oneOf: [
+              {
+                $required: true,
+                type: 'string',
+              },
+              {
+                $required: true,
+                type: 'null',
+              },
+            ],
+          })
+        );
+
+        expectType<string | null>(value);
+        // @ts-expect-error `value` should not be `number`
+        expectType<number>(value);
+        // @ts-expect-error `value` should not be `undefined`
+        expectType<undefined>(value);
+        expectType<typeof value>('foo');
+        expectType<typeof value>(null);
+      });
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,7 +213,7 @@ export function objectGeneric<Property, Options extends ObjectOptions>(
 export function oneOf<Types extends any[], Options extends GenericOptions>(
   types: Types,
   options?: Options
-): GetType<NonNullable<Types[number]>, Options> {
+): GetType<Exclude<Types[number], undefined>, Options> {
   const { required } = options || {};
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -226,7 +226,7 @@ export function oneOf<Types extends any[], Options extends GenericOptions>(
           $required: true,
         }))
       : types,
-  } as unknown as GetType<NonNullable<Types[number]>, Options>;
+  } as unknown as GetType<Exclude<Types[number], undefined>, Options>;
 }
 
 function createSimpleType<Type>(type: BSONType) {


### PR DESCRIPTION
Fixes the return type of `types.oneOf`.

Closes: #715 