### PR TITLE
fix: Export schema only once

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globa
 import { Collection, Db } from 'mongodb';
 import Papr from '../index';
 import * as model from '../model';
-import schema from '../schema';
+import { schema } from '../schema';
 import types from '../types';
 import { VALIDATION_ACTIONS, VALIDATION_LEVEL } from '../utils';
 

--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -4,7 +4,7 @@ import { expectType } from 'ts-expect';
 import { Hooks } from '../hooks';
 import { abstract, build, Model } from '../model';
 import { PaprBulkWriteOperation } from '../mongodbTypes';
-import schema from '../schema';
+import { schema } from '../schema';
 import Types from '../types';
 
 describe('model', () => {

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
 import { ObjectId, Binary, Decimal128 } from 'mongodb';
 import { expectType } from 'ts-expect';
-import schema from '../schema';
+import { schema } from '../schema';
 import types from '../types';
 import { VALIDATION_ACTIONS, VALIDATION_LEVEL } from '../utils';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Db } from 'mongodb';
 import { abstract, build, Model } from './model';
-import schema, { SchemaOptions } from './schema';
+import { SchemaOptions } from './schema';
 import types from './types';
 import { BaseSchema, ModelOptions } from './utils';
 
@@ -175,7 +175,7 @@ export default class Papr {
   }
 }
 
-export { schema, types, types as Types };
+export { types, types as Types };
 export * from './hooks';
 export * from './model';
 export * from './mongodbTypes';

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -162,7 +162,7 @@ function sanitize(value: any): void {
  * export type UserDocument = (typeof userSchema)[0];
  * export type UserOptions = (typeof userSchema)[1];
  */
-export default function schema<
+export function schema<
   TProperties extends Record<string, unknown>,
   TOptions extends SchemaOptions<TProperties>,
 >(properties: TProperties, options?: TOptions): [SchemaType<TProperties, TOptions>, TOptions] {


### PR DESCRIPTION
We have a problem using import-in-the-middle (lib embedded inside opentelemetry), because this lib intercept and register a hook of modules. I found a issue that reexport of schema module, beceuse this module is export twice on index.js. 

The exception generated using import-in-the-middle, papr, and node20:
```
file:///Users/papr/esm/index.js?iitm=true:90
    let $schema = $1707251817792598e86e3.schema
        ^

SyntaxError: Identifier '$schema' has already been declared
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:167:18)
    at callTranslator (node:internal/modules/esm/loader:285:14)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:291:30)

Node.js v20.11.0
```


Thanks in advanced.