### PR TITLE
test: Use Plex webhook URL

### DIFF
--- a/.github/workflows/plex.yaml
+++ b/.github/workflows/plex.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.head_ref, 'renovate') }}
     steps:
+      - run: "echo 'URL:${{ vars.SLACK_PAPR_WEBHOOK_URL }}'"
+
       - uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |
@@ -34,5 +36,5 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: https://hooks.slack.com/services/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
+          SLACK_WEBHOOK_URL: ${{ vars.SLACK_PAPR_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/plex.yaml
+++ b/.github/workflows/plex.yaml
@@ -34,5 +34,5 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: https://hooks.slack.com/services/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
+          SLACK_WEBHOOK_URL: https://hooks.slack.com/services/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
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/plex.yaml
+++ b/.github/workflows/plex.yaml
@@ -34,5 +34,5 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PAPR_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: https://hooks.slack.com/services/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
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/plex.yaml
+++ b/.github/workflows/plex.yaml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.head_ref, 'renovate') }}
     steps:
-      - run: "echo 'URL:${{ vars.SLACK_PAPR_WEBHOOK_URL }}'"
-
       - uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |

--- a/.github/workflows/plex.yaml
+++ b/.github/workflows/plex.yaml
@@ -34,5 +34,5 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: https://hooks.slack.com/services/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
+          SLACK_WEBHOOK_URL: https://hooks.slack.com/services/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
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Related to #722, but without using a secret, which does not work for workflows running on PRs.