### PR TITLE
feat: bulkWrite method accepts readonly operations

### DIFF
--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -291,8 +291,93 @@ describe('model', () => {
       });
     });
 
+    test('simple schema with inline operations', async () => {
+      await simpleModel.bulkWrite([
+        {
+          insertOne: {
+            document: {
+              bar: 123,
+              foo: 'foo',
+            },
+          },
+        },
+      ]);
+
+      expect(collection.bulkWrite).toHaveBeenCalledWith(
+        [
+          {
+            insertOne: {
+              document: {
+                bar: 123,
+                foo: 'foo',
+              },
+            },
+          },
+        ],
+        {
+          ignoreUndefined: true,
+        }
+      );
+    });
+
+    test('simple schema with readonly operations', async () => {
+      const operations = [
+        {
+          insertOne: {
+            document: {
+              bar: 123,
+              foo: 'foo',
+            },
+          },
+        },
+        {
+          updateOne: {
+            filter: { foo: 'foo' },
+            update: {
+              $set: { bar: 123 },
+            },
+          },
+        },
+        {
+          updateMany: {
+            filter: { foo: 'foo' },
+            update: {
+              $set: { bar: 123 },
+            },
+          },
+        },
+        {
+          replaceOne: {
+            filter: { foo: 'foo' },
+            replacement: {
+              bar: 123,
+              foo: 'foo',
+            },
+          },
+        },
+        {
+          deleteOne: {
+            filter: { foo: 'foo' },
+          },
+        },
+        {
+          deleteMany: {
+            filter: { foo: 'foo' },
+          },
+        },
+      ] as const;
+
+      expectType<readonly PaprBulkWriteOperation<SimpleDocument, SimpleOptions>[]>(operations);
+
+      await simpleModel.bulkWrite(operations);
+
+      expect(collection.bulkWrite).toHaveBeenCalledWith(operations, {
+        ignoreUndefined: true,
+      });
+    });
+
     test('schema with defaults', async () => {
-      const operations: PaprBulkWriteOperation<SimpleDocument, SimpleOptions>[] = [
+      const operations = [
         {
           insertOne: {
             document: {
@@ -366,7 +451,9 @@ describe('model', () => {
             upsert: true,
           },
         },
-      ];
+      ] as const;
+
+      expectType<readonly PaprBulkWriteOperation<SimpleDocument, SimpleOptions>[]>(operations);
 
       await simpleModel.bulkWrite(operations);
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -57,7 +57,7 @@ export interface Model<TSchema extends BaseSchema, TOptions extends SchemaOption
   ) => Promise<TResult[]>;
 
   bulkWrite: (
-    operations: PaprBulkWriteOperation<TSchema, TOptions>[],
+    operations: readonly PaprBulkWriteOperation<TSchema, TOptions>[],
     options?: BulkWriteOptions
   ) => Promise<BulkWriteResult | void>;
 
@@ -376,7 +376,7 @@ export function build<TSchema extends BaseSchema, TOptions extends SchemaOptions
   model.bulkWrite = wrap(
     model,
     async function bulkWrite(
-      operations: PaprBulkWriteOperation<TSchema, TOptions>[],
+      operations: readonly PaprBulkWriteOperation<TSchema, TOptions>[],
       options?: BulkWriteOptions
     ): Promise<BulkWriteResult | void> {
       if (operations.length === 0) {

--- a/src/mongodbTypes.ts
+++ b/src/mongodbTypes.ts
@@ -42,7 +42,7 @@ import { DocumentForInsert, NestedPaths, PropertyType } from './utils';
 // We've adopted these types in this repository and made some improvements to them.
 // See: https://github.com/plexinc/papr/issues/410
 
-// These buik operation types need our own `PaprFilter` and `PaprUpdateFilter` in their definition
+// These bulk operation types need our own `PaprFilter` and `PaprUpdateFilter` in their definition
 export type PaprBulkWriteOperation<TSchema, TOptions extends SchemaOptions<TSchema>> =
   | {
       // @ts-expect-error Type expects a Document extended type, but Document is too generic


### PR DESCRIPTION
Closes #830

As part of an attempt to improve papr's support for immutable data structures, this simple PR allows passing a readonly array of operations to the `bulkWrite` method.