### PR TITLE
docs: Use `type` instead of `const` in schema docs

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -23,7 +23,7 @@ const userSchema = schema({
 To interact with your collection using this schema, create two important derived types, the model type and the document type:
 
 ```ts
-const UserDocument = typeof userSchema[0];
+type UserDocument = typeof userSchema[0];
 const UserModel = papr.model('users', userSchema);
 ```
 


### PR DESCRIPTION
Fixes a mistake in the docs. :)