### PR TITLE
feat: Support readonly options for Types.string and Types.number

### DIFF
--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -168,12 +168,23 @@ describe('types', () => {
         });
       });
 
-      test('options', () => {
-        types.number({
+      test('options, range and modulo', () => {
+        const options = {
           maximum: 9,
           minimum: 2,
           multipleOf: 2,
-        });
+        } as const;
+        types.number(options);
+
+        // @ts-expect-error invalid option
+        types.number({ maxLength: 1 });
+      });
+
+      test('options, enum', () => {
+        const options = {
+          enum: [1, 2, 3],
+        } as const;
+        types.number(options);
 
         // @ts-expect-error invalid option
         types.number({ maxLength: 1 });
@@ -329,11 +340,12 @@ describe('types', () => {
       });
 
       test('options', () => {
-        types.string({
+        const options = {
           enum: ['foo', 'bar'],
           maxLength: 9,
           minLength: 1,
-        });
+        } as const;
+        types.string(options);
 
         // @ts-expect-error invalid option
         types.string({ maximum: 1 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ interface ArrayOptions extends GenericOptions {
 }
 
 interface NumberOptions extends GenericOptions {
-  enum?: number[];
+  enum?: readonly number[];
   exclusiveMaximum?: boolean;
   exclusiveMinimum?: boolean;
   maximum?: number;
@@ -36,7 +36,7 @@ interface ObjectOptions extends GenericOptions {
 }
 
 interface StringOptions extends GenericOptions {
-  enum?: string[];
+  enum?: readonly string[];
   maxLength?: number;
   minLength?: number;
   pattern?: string;


### PR DESCRIPTION
Although support was added for `readonly` values passed to `Types.enum`, the same functionality was not added to the `Types.string` and `Types.number` enum options member.