### PR TITLE
fix: Filter invalid values in getIds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,6 @@ Reviewers should use the following questions to evaluate the implementation for 
      - easier to maintain (easier to change, harder to accidentally break)
 
 - Housekeeping
-
   1. Does the title and description of the PR reference the correct issue and does it use the correct conventional commit type (e.g., fix, feat, test, breaking change etc)?
   1. If there are new TODOs, has a related issue been created?
   1. Should any documentation be updated?

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -79,3 +79,8 @@ enum VALIDATION_LEVEL {
   STRICT = 'strict',
 }
 ```
+
+## `getIds`
+
+Converts an iterable of ObjectId-constructable values into an array of ObjectId instances.
+Values that cannot be converted to a valid ObjectId are silently filtered out.

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { deepStrictEqual, equal, ok } from 'node:assert/strict';
+import { deepStrictEqual, ok } from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
 import { ObjectId } from 'mongodb';
@@ -8,7 +8,12 @@ import { expectType } from 'ts-expect';
 import { getDefaultValues, getIds } from '../utils.ts';
 
 import type { DefaultsOption } from '../schema.ts';
-import type { NestedPaths, ProjectionType, PropertyType } from '../utils.ts';
+import type {
+  NestedPaths,
+  ObjectIdConstructorParameter,
+  ProjectionType,
+  PropertyType,
+} from '../utils.ts';
 
 describe('utils', () => {
   interface TestDocument {
@@ -384,19 +389,88 @@ describe('utils', () => {
   });
 
   describe('getIds', () => {
-    for (const input of [
-      ['123456789012345678900001', '123456789012345678900002'],
-      [new ObjectId('123456789012345678900001'), new ObjectId('123456789012345678900002')],
-      ['123456789012345678900001', new ObjectId('123456789012345678900002')],
-    ]) {
-      test('case', () => {
-        const result = getIds(input);
+    const testCases: readonly [
+      string,
+      {
+        readonly input: readonly ObjectIdConstructorParameter[];
+        readonly expected: readonly ObjectId[];
+      },
+    ][] = [
+      [
+        'strings',
+        {
+          input: ['123456789012345678900001', '123456789012345678900002'],
+          expected: [
+            new ObjectId('123456789012345678900001'),
+            new ObjectId('123456789012345678900002'),
+          ],
+        },
+      ],
+      [
+        'ObjectIds',
+        {
+          input: [
+            new ObjectId('123456789012345678900099'),
+            new ObjectId('123456789012345678900022'),
+          ],
+          expected: [
+            new ObjectId('123456789012345678900099'),
+            new ObjectId('123456789012345678900022'),
+          ],
+        },
+      ],
+      [
+        'Uint8Arrays',
+        {
+          input: [
+            new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+            new Uint8Array([13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]),
+          ],
+          expected: [
+            new ObjectId('0102030405060708090a0b0c'),
+            new ObjectId('0d0e0f101112131415161718'),
+          ],
+        },
+      ],
+      [
+        'mixed',
+        {
+          input: ['123456789012345678900014', new ObjectId('123456789012345678900088')],
+          expected: [
+            new ObjectId('123456789012345678900014'),
+            new ObjectId('123456789012345678900088'),
+          ],
+        },
+      ],
+      [
+        'invalid values',
+        {
+          input: ['123', '123456789012345678900021'],
+          expected: [new ObjectId('123456789012345678900021')],
+        },
+      ],
+    ];
 
-        equal(result.length, 2);
-        ok(result[0] instanceof ObjectId);
-        equal(result[0].toHexString(), '123456789012345678900001');
-        ok(result[1] instanceof ObjectId);
-        equal(result[1].toHexString(), '123456789012345678900002');
+    for (const testCase of testCases) {
+      const [caseName, { input, expected }] = testCase;
+
+      test(`case ${caseName}`, () => {
+        // Given
+        ok(expected.length <= input.length);
+
+        // When
+        const actual = getIds(input);
+
+        // Then
+        deepStrictEqual(actual, expected);
+
+        const isEveryObjectId = actual.every((id) => id instanceof ObjectId);
+        ok(isEveryObjectId);
+
+        const isEveryHexEquivalent = actual.every(
+          (id, index) => id.toHexString() === expected[index].toHexString()
+        );
+        ok(isEveryHexEquivalent);
       });
     }
   });

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -445,7 +445,7 @@ describe('utils', () => {
       [
         'invalid values',
         {
-          input: ['123', '123456789012345678900021'],
+          input: ['123', '123456789012345678900021', undefined],
           expected: [new ObjectId('123456789012345678900021')],
         },
       ],
@@ -455,9 +455,6 @@ describe('utils', () => {
       const [caseName, { input, expected }] = testCase;
 
       test(`case ${caseName}`, () => {
-        // Given
-        ok(expected.length <= input.length);
-
         // When
         const actual = getIds(input);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,7 +200,6 @@ export function oneOf<Types extends any[], Options extends GenericOptions>(
 ): GetType<Exclude<Types[number], undefined>, Options> {
   const { required } = options || {};
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return {
     ...(required ? { $required: true } : {}),
     oneOf: required

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -210,11 +210,21 @@ export type RequireAtLeastOne<TObj, Keys extends keyof TObj = keyof TObj> = {
 }[Keys] &
   Pick<TObj, Exclude<keyof TObj, Keys>>;
 
+/** Valid parameter types for the `ObjectId` constructor. */
 export type ObjectIdConstructorParameter = ConstructorParameters<typeof ObjectId>[0];
+
+/**
+ * Converts an iterable of ObjectId-constructable values into an array of ObjectId instances.
+ * Values that cannot be converted to a valid ObjectId are silently filtered out.
+ */
 export function getIds(ids: Iterable<ObjectIdConstructorParameter>): ObjectId[] {
   return Array.from(ids).flatMap((id) => {
+    if (id === undefined) {
+      return [];
+    }
+
     try {
-      return new ObjectId(id);
+      return [new ObjectId(id)]; // It's safer to wrap it in an array in case ObjectId is iterable in the future
     } catch {
       // Intentionally empty
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -210,8 +210,17 @@ export type RequireAtLeastOne<TObj, Keys extends keyof TObj = keyof TObj> = {
 }[Keys] &
   Pick<TObj, Exclude<keyof TObj, Keys>>;
 
-export function getIds(ids: Set<string> | readonly (ObjectId | string)[]): ObjectId[] {
-  return [...ids].map((id) => new ObjectId(id));
+export type ObjectIdConstructorParameter = ConstructorParameters<typeof ObjectId>[0];
+export function getIds(ids: Iterable<ObjectIdConstructorParameter>): ObjectId[] {
+  return Array.from(ids).flatMap((id) => {
+    try {
+      return new ObjectId(id);
+    } catch {
+      // Intentionally empty
+    }
+
+    return [];
+  });
 }
 
 /**


### PR DESCRIPTION
## 🏋️ `getIds` robustness

`getIds` is a useful utility function, but it accepts a limited subset of the valid ObjectId constructor argument types, and throws when presented with invalid input.

It's not straight-forward to filter inputs to be valid constructor arguments; in some codebases we maintain bespoke utilities for performing these checks (eg; `isValidObjectId`).

Unfortunately, the canonical validation for whether one of these arguments is a valid argument to the `ObjectId` constructor is [cooked-in to the constructor itself](https://github.com/mongodb/js-bson/blob/26549d94c50c550d5fcdd08ec12da000b81a5074/src/objectid.ts#L87-L127).

Therefore, rather than re-implementing this logic (or trying to get it extracted and exposed upstream), I updated the `getIds` implementation to rely on the constructor logic through `try/catch`, and to discard invalid elements.

### 🐤 Backwards-Compatibility

<details>
<summary>Per <a href="https://github.com/plexinc/papr/pull/979#issuecomment-2541006143">discussion</a>, this is going to be a breaking change.</summary>

~In order to keep the change backwards-compatible, I gated the filtering functionality behind a `filterInvalid` option, passed to `getIds`. If we were okay with making a breaking release, I think this would be much nicer as the default behavior.~
</details>

### 🔧  Changes

I updated `getAll` (🟦) and its specs (🟡) in a few ways.

* [x] 🟦 make `getAll` accept an `Iterable<ObjectIdConstructorParameter>`, widening acceptable input types
* [x] 🟦 ~add optional `GetIdsOptions` argument to `getIds`, with optional `filterInvalid` boolean member~
* [x] 🟦 change `getIds` inner `map` to `flatMap`, to allow single-pass filtering
* [x] 🟦 add `try/catch` to `getIds` inner `flatMap`, to rely on ObjectId constructor validation behavior
* [x] 🟦 ~add error re-throw to `getIds` inner `flatMap`, gated on `filterInvalid` option~
* [x] 🟡 make expected result part of each test case
* [x] 🟡 introduce variety between test case values / fixtures
* [x] 🟡 add invariant check that expected result length must be less-than-or-equal-to input length
* [x] 🟡 add test cases for Uint8Array arguments
* [x] 🟡 add test cases for invalid input
* [x] 🟡 ~add test case for invalid input with no `filterInvalid` option~
