### PR TITLE
Include Papr version details in MongoDB handshake

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -139,7 +139,7 @@ export default defineConfig(
       'import/no-named-as-default-member': 'off',
       'import/no-relative-parent-imports': 'error',
       'import/no-self-import': 'error',
-      'import/no-unresolved': ['error'],
+      'import/no-unresolved': ['error', { ignore: ['^#'] }],
       'import/no-useless-path-segments': 'error',
       'import/order': [
         'error',

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "type": "module",
   "types": "./lib/index.d.ts",
   "exports": "./lib/index.js",
+  "imports": {
+    "#package.json": "./package.json"
+  },
   "files": [
     "lib/*"
   ],

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
   "type": "module",
   "types": "./lib/index.d.ts",
   "exports": "./lib/index.js",
-  "imports": {
-    "#package.json": "./package.json"
-  },
   "files": [
     "lib/*"
   ],

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -78,6 +78,22 @@ describe('index', () => {
       strictEqual(model.build.mock.callCount(), 0);
     });
 
+    test('initialize calls appendMetadata when available', () => {
+      const appendMetadata = mock.fn();
+      const dbWithClient = {
+        ...db,
+        client: { appendMetadata },
+      };
+
+      const papr = new Papr();
+      papr.initialize(dbWithClient as any);
+
+      strictEqual(appendMetadata.mock.callCount(), 1);
+      const args = appendMetadata.mock.calls[0].arguments[0];
+      strictEqual(args.name, 'Papr');
+      strictEqual(typeof args.version, 'string');
+    });
+
     test('define model without db', async () => {
       const papr = new Papr();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Db } from 'mongodb';
-import { version } from '../package.json' with { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 import { abstract, build } from './model.ts';
 import types from './types.ts';
@@ -60,7 +60,7 @@ export default class Papr {
     }
 
     if (typeof db.client?.appendMetadata === 'function') {
-      db.client.appendMetadata({ name: 'Papr', version });
+      db.client.appendMetadata({ name: 'Papr', version: pkg.version });
     }
 
     this.db = db;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Db } from 'mongodb';
+import { version } from '../package.json' with { type: 'json' };
 
 import { abstract, build } from './model.ts';
 import types from './types.ts';
@@ -57,6 +58,8 @@ export default class Papr {
     if (this.db) {
       return;
     }
+
+    db.client.appendMetadata({ name: 'Papr', version });
 
     this.db = db;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,9 @@ export default class Papr {
       return;
     }
 
-    db.client.appendMetadata({ name: 'Papr', version });
+    if (typeof db.client.appendMetadata === 'function') {
+      db.client.appendMetadata({ name: 'Papr', version });
+    }
 
     this.db = db;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export default class Papr {
       return;
     }
 
-    if (typeof db.client.appendMetadata === 'function') {
+    if (typeof db.client?.appendMetadata === 'function') {
       db.client.appendMetadata({ name: 'Papr', version });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { Db } from 'mongodb';
-import pkg from '../package.json' with { type: 'json' };
 
 import { abstract, build } from './model.ts';
 import types from './types.ts';
@@ -7,6 +6,8 @@ import types from './types.ts';
 import type { Model } from './model.ts';
 import type { SchemaOptions } from './schema.ts';
 import type { BaseSchema, ModelOptions } from './utils.ts';
+
+import pkg from '#package.json' with { type: 'json' };
 
 export default class Papr {
   db?: Db;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module';
+
 import { Db } from 'mongodb';
 
 import { abstract, build } from './model.ts';
@@ -7,7 +9,8 @@ import type { Model } from './model.ts';
 import type { SchemaOptions } from './schema.ts';
 import type { BaseSchema, ModelOptions } from './utils.ts';
 
-import pkg from '#package.json' with { type: 'json' };
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as { version: string };
 
 export default class Papr {
   db?: Db;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "strictFunctionTypes": false,
     "target": "es2023",
     "types": ["node"],
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true
   },
   "include": ["./example", "./src"]


### PR DESCRIPTION
The PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to `mongos` or `mongod` logs.

For example, this change would allow server-side logs such as the following:

> {"t":{"$date":"2024-01-27T23:10:40.108Z"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn16235","msg":"client metadata","attr":{"remote":"127.0.0.1:1094","client":"conn16235","doc":{"driver":{`"name":"nodejs|Papr"`,`"version":"6.12.0|16.0.0"`},"platform":"Node.js v18.18.2, LE","os":{"name":"linux","architecture":"x64","version":"5.15.133+","type":"Linux"}}}}

For anyone hosting clusters with connections coming from different applications this can help differentiate connections and facilitate log analysis.