### PR TITLE
feat: Check required schema properties in upsert updates

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -469,13 +469,19 @@ const result = await User.updateOne({ firstName: 'John' }, { $set: { age: 40 } }
 
 Calls the MongoDB [`findOneAndUpdate()`](https://mongodb.github.io/node-mongodb-native/5.0/classes/Collection.html#findOneAndUpdate) method with the `upsert` option enabled.
 
+When no document matches the filter, MongoDB inserts a new document built from the filter
+equality fields and the update operator fields (plus the schema defaults and timestamps).
+The `update` argument is type-checked so that all the required properties in the schema
+are provided by one of these sources, otherwise the missing properties must be present
+in the `$setOnInsert` operator.
+
 **Parameters:**
 
-| Name      | Type                        | Attribute |
-| --------- | --------------------------- | --------- |
-| `filter`  | `PaprFilter<TSchema>`       | required  |
-| `update`  | `PaprUpdateFilter<TSchema>` | required  |
-| `options` | `FindOneAndUpdateOptions`   | optional  |
+| Name      | Type                              | Attribute |
+| --------- | --------------------------------- | --------- |
+| `filter`  | `PaprFilter<TSchema>`             | required  |
+| `update`  | `PaprUpsertUpdateFilter<TSchema>` | required  |
+| `options` | `FindOneAndUpdateOptions`         | optional  |
 
 **Returns:**
 
@@ -493,4 +499,11 @@ const userProjected = await User.upsert(
 );
 userProjected.firstName; // TypeScript error
 userProjected.lastName; // valid
+
+await User.upsert(
+  { firstName: 'John' },
+  // TypeScript error: `lastName` is required on insert
+  // and is not provided by the filter or the update
+  { $set: { age: 40 } }
+);
 ```

--- a/src/__tests__/model.test.ts
+++ b/src/__tests__/model.test.ts
@@ -14,7 +14,7 @@ import type { Mock } from 'node:test';
 
 import type { Hooks } from '../hooks.ts';
 import type { Model } from '../model.ts';
-import type { PaprBulkWriteOperation } from '../mongodbTypes.ts';
+import type { PaprBulkWriteOperation, PaprFilter, PaprUpdateFilter } from '../mongodbTypes.ts';
 
 const MOCK_DATE = new Date(1234567890000);
 
@@ -140,6 +140,13 @@ describe('model', () => {
     }
   );
 
+  // Schema without any options, used for testing the required properties check in `upsert`
+  // https://github.com/plexinc/papr/issues/1019
+  const noOptionsSchema = schema({
+    name: Types.string({ required: true }),
+    website: Types.string({ required: true }),
+  });
+
   type SimpleDocument = (typeof simpleSchema)[0];
   type SimpleOptions = (typeof simpleSchema)[1];
   type TimestampsDocument = (typeof timestampsSchema)[0];
@@ -150,12 +157,15 @@ describe('model', () => {
   type NumericIdOptions = (typeof numericIdSchema)[1];
   type DynamicDefaultsDocument = (typeof dynamicDefaultsSchema)[0];
   type DynamicDefaultsOptions = (typeof dynamicDefaultsSchema)[1];
+  type NoOptionsDocument = (typeof noOptionsSchema)[0];
+  type NoOptionsOptions = (typeof noOptionsSchema)[1];
 
   let simpleModel: Model<SimpleDocument, SimpleOptions>;
   let timestampsModel: Model<TimestampsDocument, TimestampsOptions>;
   let timestampConfigModel: Model<TimestampConfigDocument, TimestampConfigOptions>;
   let numericIdModel: Model<NumericIdDocument, NumericIdOptions>;
   let dynamicDefaultsModel: Model<DynamicDefaultsDocument, DynamicDefaultsOptions>;
+  let noOptionsModel: Model<NoOptionsDocument, NoOptionsOptions>;
 
   let doc: SimpleDocument;
   let docs: SimpleDocument[];
@@ -249,6 +259,11 @@ describe('model', () => {
     dynamicDefaultsModel = abstract(dynamicDefaultsSchema);
     // @ts-expect-error Ignore schema types
     build(dynamicDefaultsSchema, dynamicDefaultsModel, collection);
+
+    // @ts-expect-error Ignore abstract assignment
+    noOptionsModel = abstract(noOptionsSchema);
+    // @ts-expect-error Ignore schema types
+    build(noOptionsSchema, noOptionsModel, collection);
 
     mock.timers.enable({
       apis: ['Date'],
@@ -2715,6 +2730,69 @@ describe('model', () => {
       collection.findOneAndUpdate = mock.fn(() => {
         throw new Error('findOneAndUpdate failed');
       });
+    });
+
+    test('enforces required properties on insert', async () => {
+      const date = new Date();
+
+      // https://github.com/plexinc/papr/issues/1019
+      await noOptionsModel.upsert(
+        { website: 'example.com' },
+        // @ts-expect-error `name` is required on insert and not provided by the filter or update
+        { $set: {}, $setOnInsert: {} }
+      );
+
+      // @ts-expect-error `foo` is required on insert and not provided by the filter or update
+      await simpleModel.upsert({ bar: 123 }, { $set: { ham: date } });
+
+      // timestamps properties are not required on insert, but other required properties still are
+      // @ts-expect-error `foo` is required on insert and not provided by the filter or update
+      await timestampsModel.upsert({}, { $setOnInsert: { bar: 123 } });
+
+      // fields inside `$or` clauses do not contribute to the inserted document
+      await noOptionsModel.upsert(
+        { $or: [{ name: 'foo' }] },
+        // @ts-expect-error `name` is required on insert and not provided by the filter or update
+        { $set: { website: 'example.com' } }
+      );
+    });
+
+    test('allows required properties on insert from multiple sources', async () => {
+      const date = new Date();
+
+      // required properties provided via `$set`
+      await noOptionsModel.upsert({}, { $set: { name: 'foo', website: 'example.com' } });
+
+      // required properties provided via `$setOnInsert`
+      await noOptionsModel.upsert(
+        { website: 'example.com' },
+        { $set: {}, $setOnInsert: { name: 'foo' } }
+      );
+
+      // required properties provided via filter equality fields
+      await noOptionsModel.upsert({ name: 'foo', website: 'example.com' }, { $set: {} });
+
+      // required properties provided via `$and` filter clauses
+      await noOptionsModel.upsert(
+        { $and: [{ name: 'foo' }, { website: 'example.com' }] },
+        { $set: {} }
+      );
+
+      // properties with defaults (`bar`) and optional properties (`ham`, `nested`) are not required
+      await simpleModel.upsert({}, { $set: { foo: 'foo' } });
+      await dynamicDefaultsModel.upsert({}, { $setOnInsert: { foo: 'foo' } });
+
+      // timestamps properties are not required on insert
+      await timestampsModel.upsert({ foo: 'foo' }, { $set: { ham: date } });
+      await timestampConfigModel.upsert({ foo: 'foo' }, { $set: { ham: date } });
+
+      // dot-notation keys provide their root property (`nested`)
+      await simpleModel.upsert({ foo: 'foo' }, { $set: { 'nested.direct': 'foo' } });
+
+      // non-literal filters and updates are not checked
+      const filter: PaprFilter<SimpleDocument> = {};
+      const update: PaprUpdateFilter<SimpleDocument> = {};
+      await simpleModel.upsert(filter, update);
     });
   });
 });

--- a/src/__tests__/mongodbTypes.test.ts
+++ b/src/__tests__/mongodbTypes.test.ts
@@ -15,7 +15,10 @@ import {
 } from 'mongodb';
 import { expectType } from 'ts-expect';
 
-import type { PaprFilter, PaprUpdateFilter } from '../mongodbTypes.ts';
+import type { TypeEqual } from 'ts-expect';
+
+import type { PaprFilter, PaprUpdateFilter, PaprUpsertUpdateFilter } from '../mongodbTypes.ts';
+import type { SchemaOptions } from '../schema.ts';
 
 describe('mongodb types', () => {
   interface TestDocument {
@@ -1042,6 +1045,180 @@ describe('mongodb types', () => {
           // expectType<PaprUpdateFilter<TestDocument>>({ $set: { 'list.$[].direct': 123 } });
         });
       });
+    });
+  });
+
+  describe('PaprUpsertUpdateFilter', () => {
+    interface UpsertTestDocument {
+      _id: ObjectId;
+      counter: number;
+      name: string;
+      seenAt: Date;
+      tags: string[];
+      nestedObject: { deep: string };
+      optional?: string;
+    }
+    type UpsertTestOptions = SchemaOptions<UpsertTestDocument>;
+
+    type Check<
+      TFilter extends PaprFilter<UpsertTestDocument>,
+      TUpdate extends PaprUpdateFilter<UpsertTestDocument>,
+      TOptions extends SchemaOptions<UpsertTestDocument> = UpsertTestOptions,
+    > = PaprUpsertUpdateFilter<UpsertTestDocument, TOptions, TFilter, TUpdate>;
+
+    // The check resolves to `unknown` when all required properties are provided on insert
+    type Provided<TCheck> = TypeEqual<TCheck, unknown>;
+
+    // This needs to be a type instead of an interface, because interfaces do not receive
+    // the implicit index signatures required for `PaprMatchKeysAndValues` assignability
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    type FullSet = {
+      counter: number;
+      name: string;
+      seenAt: Date;
+      tags: string[];
+      nestedObject: { deep: string };
+    };
+
+    test('update operators which create missing fields provide properties', () => {
+      expectType<Provided<Check<Record<never, never>, { $set: FullSet }>>>(true);
+      expectType<Provided<Check<Record<never, never>, { $setOnInsert: FullSet }>>>(true);
+
+      // multiple update operators provide properties together
+      expectType<
+        Provided<
+          Check<
+            Record<never, never>,
+            {
+              $currentDate: { seenAt: true };
+              $inc: { counter: number };
+              $push: { tags: string };
+              $set: { name: string };
+              $setOnInsert: { nestedObject: { deep: string } };
+            }
+          >
+        >
+      >(true);
+
+      expectType<
+        Provided<
+          Check<Record<never, never>, { $addToSet: { tags: string }; $set: Omit<FullSet, 'tags'> }>
+        >
+      >(true);
+      expectType<
+        Provided<
+          Check<Record<never, never>, { $min: { counter: number }; $set: Omit<FullSet, 'counter'> }>
+        >
+      >(true);
+      expectType<
+        Provided<
+          Check<Record<never, never>, { $max: { counter: number }; $set: Omit<FullSet, 'counter'> }>
+        >
+      >(true);
+      expectType<
+        Provided<
+          Check<Record<never, never>, { $mul: { counter: number }; $set: Omit<FullSet, 'counter'> }>
+        >
+      >(true);
+      expectType<
+        Provided<
+          Check<
+            Record<never, never>,
+            { $bit: { counter: { and: number } }; $set: Omit<FullSet, 'counter'> }
+          >
+        >
+      >(true);
+
+      // dot-notation keys provide their root property
+      expectType<
+        Provided<
+          Check<
+            Record<never, never>,
+            { $set: Omit<FullSet, 'nestedObject'> & { 'nestedObject.deep': string } }
+          >
+        >
+      >(true);
+    });
+
+    test('update operators which do not create missing fields do not provide properties', () => {
+      expectType<
+        Provided<
+          Check<Record<never, never>, { $pull: { tags: string }; $set: Omit<FullSet, 'tags'> }>
+        >
+      >(false);
+      expectType<
+        Provided<Check<Record<never, never>, { $unset: { tags: 1 }; $set: Omit<FullSet, 'tags'> }>>
+      >(false);
+    });
+
+    test('filter equality fields provide properties', () => {
+      expectType<Provided<Check<{ counter: number }, { $set: Omit<FullSet, 'counter'> }>>>(true);
+
+      // dot-notation keys provide their root property
+      expectType<
+        Provided<Check<{ 'nestedObject.deep': string }, { $set: Omit<FullSet, 'nestedObject'> }>>
+      >(true);
+
+      // fields inside `$and` clauses provide properties
+      expectType<
+        Provided<
+          Check<
+            { $and: [{ counter: number }, { name: string }] },
+            { $set: Omit<FullSet, 'counter' | 'name'> }
+          >
+        >
+      >(true);
+
+      // fields using comparison operators are treated as provided properties
+      // (they cannot be reliably told apart from direct equality values)
+      expectType<Provided<Check<{ counter: { $gt: number } }, { $set: Omit<FullSet, 'counter'> }>>>(
+        true
+      );
+
+      // fields inside `$or` clauses do not provide properties
+      expectType<
+        Provided<Check<{ $or: [{ counter: number }] }, { $set: Omit<FullSet, 'counter'> }>>
+      >(false);
+    });
+
+    test('schema defaults provide properties', () => {
+      expectType<
+        Provided<
+          Check<
+            Record<never, never>,
+            { $set: Omit<FullSet, 'counter'> },
+            { defaults: { counter: number } }
+          >
+        >
+      >(true);
+
+      expectType<
+        Provided<
+          Check<
+            Record<never, never>,
+            { $set: Omit<FullSet, 'counter'> },
+            { defaults: () => { counter: number } }
+          >
+        >
+      >(true);
+    });
+
+    test('missing required properties are required in $setOnInsert', () => {
+      expectType<Provided<Check<Record<never, never>, { $set: Omit<FullSet, 'name'> }>>>(false);
+
+      expectType<
+        TypeEqual<
+          Check<Record<never, never>, { $set: Omit<FullSet, 'name'> }>,
+          { $setOnInsert: { name: string } }
+        >
+      >(true);
+    });
+
+    test('non-literal filters and updates provide all properties', () => {
+      expectType<Provided<Check<PaprFilter<UpsertTestDocument>, { $set: Record<never, never> }>>>(
+        true
+      );
+      expectType<Provided<Check<Record<never, never>, PaprUpdateFilter<UpsertTestDocument>>>>(true);
     });
   });
 });

--- a/src/model.ts
+++ b/src/model.ts
@@ -34,7 +34,12 @@ import type {
   WithId,
 } from 'mongodb';
 
-import type { PaprBulkWriteOperation, PaprFilter, PaprUpdateFilter } from './mongodbTypes.ts';
+import type {
+  PaprBulkWriteOperation,
+  PaprFilter,
+  PaprUpdateFilter,
+  PaprUpsertUpdateFilter,
+} from './mongodbTypes.ts';
 import type { DefaultsOption, SchemaOptions, SchemaTimestampOptions } from './schema.ts';
 import type {
   BaseSchema,
@@ -136,9 +141,13 @@ export interface Model<TSchema extends BaseSchema, TOptions extends SchemaOption
     options?: UpdateOptions
   ) => Promise<UpdateResult>;
 
-  upsert: <TProjection extends Projection<TSchema> | undefined>(
-    filter: PaprFilter<TSchema>,
-    update: PaprUpdateFilter<TSchema>,
+  upsert: <
+    TProjection extends Projection<TSchema> | undefined,
+    TFilter extends PaprFilter<TSchema> = PaprFilter<TSchema>,
+    TUpdate extends PaprUpdateFilter<TSchema> = PaprUpdateFilter<TSchema>,
+  >(
+    filter: TFilter,
+    update: PaprUpsertUpdateFilter<TSchema, TOptions, TFilter, TUpdate> & TUpdate,
     options?: Omit<FindOneAndUpdateOptions, 'projection' | 'upsert'> & { projection?: TProjection }
   ) => Promise<ProjectionType<TSchema, TProjection>>;
 }
@@ -1043,8 +1052,14 @@ export function build<TSchema extends BaseSchema, TOptions extends SchemaOptions
    * @description
    * Calls the MongoDB [`findOneAndUpdate()`](https://mongodb.github.io/node-mongodb-native/5.0/classes/Collection.html#findOneAndUpdate) method with the `upsert` option enabled.
    *
+   * When no document matches the filter, MongoDB inserts a new document built from the filter
+   * equality fields and the update operator fields (plus the schema defaults and timestamps).
+   * The `update` argument is type-checked so that all the required properties in the schema
+   * are provided by one of these sources, otherwise the missing properties must be present
+   * in the `$setOnInsert` operator.
+   *
    * @param filter {PaprFilter<TSchema>}
-   * @param update {PaprUpdateFilter<TSchema>}
+   * @param update {PaprUpsertUpdateFilter<TSchema>}
    * @param [options] {FindOneAndUpdateOptions}
    *
    * @returns {Promise<TSchema>}
@@ -1062,10 +1077,21 @@ export function build<TSchema extends BaseSchema, TOptions extends SchemaOptions
    * );
    * userProjected.firstName; // TypeScript error
    * userProjected.lastName; // valid
+   *
+   * await User.upsert(
+   *   { firstName: 'John' },
+   *   // TypeScript error: `lastName` is required on insert
+   *   // and is not provided by the filter or the update
+   *   { $set: { age: 40 } }
+   * );
    */
-  model.upsert = async function upsert<TProjection extends Projection<TSchema> | undefined>(
-    filter: PaprFilter<TSchema>,
-    update: PaprUpdateFilter<TSchema>,
+  model.upsert = async function upsert<
+    TProjection extends Projection<TSchema> | undefined,
+    TFilter extends PaprFilter<TSchema> = PaprFilter<TSchema>,
+    TUpdate extends PaprUpdateFilter<TSchema> = PaprUpdateFilter<TSchema>,
+  >(
+    filter: TFilter,
+    update: PaprUpsertUpdateFilter<TSchema, TOptions, TFilter, TUpdate> & TUpdate,
     options?: Omit<FindOneAndUpdateOptions, 'projection' | 'upsert'> & { projection?: TProjection }
   ): Promise<ProjectionType<TSchema, TProjection>> {
     const item = await model.findOneAndUpdate(filter, update, {

--- a/src/mongodbTypes.ts
+++ b/src/mongodbTypes.ts
@@ -27,7 +27,7 @@ import type {
 } from 'mongodb';
 
 import type { SchemaOptions } from './schema.ts';
-import type { DocumentForInsert, NestedPaths, PropertyType } from './utils.ts';
+import type { DocumentForInsert, NestedPaths, PropertyType, RequiredProperties } from './utils.ts';
 
 // Some of the types are adapted from originals at: https://github.com/mongodb/node-mongodb-native/blob/v5.0.1/src/mongo_types.ts
 // licensed under Apache License 2.0: https://github.com/mongodb/node-mongodb-native/blob/v5.0.1/LICENSE.md
@@ -202,6 +202,103 @@ export type PaprArrayNestedProperties<TSchema> = {
 export type PaprMatchKeysAndValues<TSchema> = PaprAllProperties<TSchema> &
   PaprArrayElementsProperties<TSchema> &
   PaprArrayNestedProperties<TSchema>;
+
+/**
+ * Extracts the root property name from a (possibly dot-notation) key.
+ *
+ * @example
+ * 'nestedObject.direct' -> 'nestedObject'
+ * 'foo' -> 'foo'
+ */
+type RootProperty<Property> = Property extends `${infer Root}.${string}` ? Root : Property;
+
+/**
+ * Returns the root properties of the top-level equality fields in a filter,
+ * including the fields inside top-level `$and` clauses (one level deep).
+ *
+ * During an upsert operation these fields are included in the newly inserted document:
+ * https://www.mongodb.com/docs/manual/reference/method/db.collection.update/#upsert-behavior
+ *
+ * Note: Fields using comparison operators (e.g. `{ foo: { $gt: 1 } }`) are not equality fields
+ * and are not included in the inserted document, but they are intentionally treated here
+ * as provided properties, because telling them apart from direct object values is unreliable.
+ */
+type PaprFilterProvidedProperties<TFilter> =
+  | Exclude<RootProperty<string & keyof TFilter>, `$${string}`>
+  | (TFilter extends { $and: readonly (infer TClause)[] }
+      ? TClause extends unknown
+        ? Exclude<RootProperty<string & keyof TClause>, `$${string}`>
+        : never
+      : never);
+
+/**
+ * Returns the root properties referenced by an update operator's fields.
+ */
+type PaprUpdateOperatorProperties<TOperator> = TOperator extends object
+  ? RootProperty<string & keyof TOperator>
+  : never;
+
+/**
+ * Returns the root properties created on the inserted document during an upsert operation
+ * by the update operators which create missing fields.
+ *
+ * https://www.mongodb.com/docs/manual/reference/operator/update/#fields
+ */
+type PaprUpdateProvidedProperties<TSchema, TUpdate extends PaprUpdateFilter<TSchema>> =
+  | PaprUpdateOperatorProperties<TUpdate['$addToSet']>
+  | PaprUpdateOperatorProperties<TUpdate['$bit']>
+  | PaprUpdateOperatorProperties<TUpdate['$currentDate']>
+  | PaprUpdateOperatorProperties<TUpdate['$inc']>
+  | PaprUpdateOperatorProperties<TUpdate['$max']>
+  | PaprUpdateOperatorProperties<TUpdate['$min']>
+  | PaprUpdateOperatorProperties<TUpdate['$mul']>
+  | PaprUpdateOperatorProperties<TUpdate['$push']>
+  | PaprUpdateOperatorProperties<TUpdate['$set']>
+  | PaprUpdateOperatorProperties<TUpdate['$setOnInsert']>;
+
+/**
+ * Returns the required properties in the schema which are not provided by any of the sources
+ * contributing to the document created by the insert branch of an upsert operation:
+ *
+ * - the filter equality fields;
+ * - the update operator fields;
+ * - the schema defaults and timestamps (via `DocumentForInsert`).
+ */
+type PaprUpsertMissingProperties<
+  TSchema,
+  TOptions extends SchemaOptions<TSchema>,
+  TFilter extends PaprFilter<TSchema>,
+  TUpdate extends PaprUpdateFilter<TSchema>,
+> = Exclude<
+  NonNullable<RequiredProperties<DocumentForInsert<TSchema, TOptions>>> & string,
+  PaprFilterProvidedProperties<TFilter> | PaprUpdateProvidedProperties<TSchema, TUpdate>
+>;
+
+/**
+ * Checks that the document created by the insert branch of an upsert operation
+ * contains all the required properties in the schema.
+ *
+ * Resolves to `unknown` when all required properties are provided by the filter equality fields,
+ * the update operators, the schema defaults or the timestamps.
+ * Otherwise, it requires the missing properties in the `$setOnInsert` operator.
+ *
+ * Non-literal filter or update types (e.g. `PaprFilter<TSchema>`) provide all their properties,
+ * so they skip this check.
+ */
+export type PaprUpsertUpdateFilter<
+  TSchema,
+  TOptions extends SchemaOptions<TSchema>,
+  TFilter extends PaprFilter<TSchema>,
+  TUpdate extends PaprUpdateFilter<TSchema>,
+> = [PaprUpsertMissingProperties<TSchema, TOptions, TFilter, TUpdate>] extends [never]
+  ? unknown
+  : {
+      $setOnInsert: {
+        [
+          Property in PaprUpsertMissingProperties<TSchema, TOptions, TFilter, TUpdate>
+        ]: PropertyType<TSchema, Property>;
+      };
+    };
 
 export interface PaprUpdateFilter<TSchema> {
   $currentDate?: OnlyFieldsOfType<

--- a/tests/ts-nodenext/index.ts
+++ b/tests/ts-nodenext/index.ts
@@ -100,6 +100,37 @@ async function run(): Promise<void> {
       updatedAt: Date;
     }[]
   >(docs);
+
+  // upserting documents
+
+  const doc3 = await Sample.upsert(
+    { firstName: 'Jane' },
+    { $set: { age: 20 }, $setOnInsert: { lastName: 'Doe' } }
+  );
+  assert.strictEqual(typeof doc3, 'object');
+  assert.strictEqual(doc3.firstName, 'Jane');
+  assert.strictEqual(doc3.lastName, 'Doe');
+  assert.strictEqual(doc3.age, 20);
+
+  expectType<{
+    _id: ObjectId;
+    age?: number;
+    city?: string;
+    createdAt: Date;
+    firstName: string;
+    lastName: string;
+    updatedAt: Date;
+  }>(doc3);
+
+  // upserting a document missing required properties on insert fails
+  // both the TypeScript check and the MongoDB JSON schema validation
+  await assert.rejects(
+    Sample.upsert(
+      { firstName: 'Judy' },
+      // @ts-expect-error `lastName` is required on insert and not provided by the filter or update
+      { $set: { age: 30 } }
+    )
+  );
 }
 
 async function teardown(): Promise<void> {

--- a/tests/ts/index.ts
+++ b/tests/ts/index.ts
@@ -100,6 +100,37 @@ async function run(): Promise<void> {
       updatedAt: Date;
     }[]
   >(docs);
+
+  // upserting documents
+
+  const doc3 = await Sample.upsert(
+    { firstName: 'Jane' },
+    { $set: { age: 20 }, $setOnInsert: { lastName: 'Doe' } }
+  );
+  assert.strictEqual(typeof doc3, 'object');
+  assert.strictEqual(doc3.firstName, 'Jane');
+  assert.strictEqual(doc3.lastName, 'Doe');
+  assert.strictEqual(doc3.age, 20);
+
+  expectType<{
+    _id: ObjectId;
+    age?: number;
+    city?: string;
+    createdAt: Date;
+    firstName: string;
+    lastName: string;
+    updatedAt: Date;
+  }>(doc3);
+
+  // upserting a document missing required properties on insert fails
+  // both the TypeScript check and the MongoDB JSON schema validation
+  await assert.rejects(
+    Sample.upsert(
+      { firstName: 'Judy' },
+      // @ts-expect-error `lastName` is required on insert and not provided by the filter or update
+      { $set: { age: 30 } }
+    )
+  );
 }
 
 async function teardown(): Promise<void> {


### PR DESCRIPTION
Fixes #1019

## Problem

`Model.upsert` accepted update filters which, when the upsert inserted a new document, produced documents missing required schema properties. The compiler was silent and the operation only failed at runtime with a MongoDB document validation error:

```ts
const companySchema = schema({
  name: types.string({ required: true }),
  website: types.string({ required: true }),
});

// No TypeScript error before this change,
// but fails at runtime with "Document failed validation"
await companyModel.upsert({ website: 'example.com' }, { $set: {}, $setOnInsert: {} });
```

## Solution

The `update` argument of `upsert` is now checked against a new `PaprUpsertUpdateFilter` type, which verifies that every required property in the schema is provided by at least one of the sources MongoDB and papr use to build the inserted document:

- the filter equality fields (top-level keys, including inside top-level `$and` clauses; dot-notation keys count for their root property);
- the update operators which create missing fields on insert (`$set`, `$setOnInsert`, `$inc`, `$mul`, `$min`, `$max`, `$push`, `$addToSet`, `$currentDate`, `$bit`);
- the schema `defaults` (static and dynamic) and the `timestamps` options (reusing the existing `DocumentForInsert` type).

When required properties are missing, the type resolves to `{ $setOnInsert: { ...missing } }`, so the compiler error names exactly the properties to add:

```
Property 'name' is missing in type '{}' but required in type '{ name: string; }'.
```

### Design notes and limitations

- Fields using comparison operators in the filter (e.g. `{ foo: { $gt: 1 } }`) are treated as provided, because they cannot be reliably distinguished from direct object equality values at the type level. This keeps the check free of false positives, at the cost of not flagging some unsafe calls.
- Fields inside `$or`/`$nor` clauses are not treated as provided (MongoDB does not copy them into the inserted document).
- Non-literal filters and updates (values typed as `PaprFilter<TSchema>` / `PaprUpdateFilter<TSchema>`) skip the check, since their keys cannot be known statically.
- `updateMany` with `upsert: true` in its options and `bulkWrite` update operations with `upsert: true` still accept unchecked updates — happy to tackle those in a follow-up if this approach is accepted.

## Breaking change

Code which previously compiled but could insert invalid documents at runtime now fails to compile; the fix is to provide the missing properties in `$setOnInsert` (or `$set`). Marked as `BREAKING CHANGE` in the commit footer, matching how the previous type-strictness changes were released (e.g. #430 in v15.0.0).

## Testing

- `pnpm test` — 242 tests pass, including new tests in `model.test.ts` (call-site enforcement, including the exact #1019 repro schema) and `mongodbTypes.test.ts` (unit tests for the new type: per-operator behavior, `$and`/`$or` handling, dot-notation keys, defaults).
- `pnpm test:types`, `pnpm lint` and `pnpm pretty:ci` are clean.
- `./tests/run.sh` — the full integration suite passes against a real MongoDB 6.0.16, and the TS fixtures compile against the built package with TypeScript 5.6. A new end-to-end case verifies that the new type error and MongoDB's runtime JSON schema validation reject the same upsert call.
- Docs regenerated with `node docs/build.js`.
